### PR TITLE
Update Spree::Order::PAYMENT_STATES with valid states

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -3,7 +3,7 @@ require 'spree/order/checkout'
 
 module Spree
   class Order < Spree::Base
-    PAYMENT_STATES = %w(balance_due checkout completed credit_owed failed paid pending processing void).freeze
+    PAYMENT_STATES = %w(balance_due credit_owed failed paid void).freeze
     SHIPMENT_STATES = %w(backorder canceled partial pending ready shipped).freeze
 
     extend FriendlyId


### PR DESCRIPTION
This constant was showing wrong payment states in this [file](https://github.com/vinsol/spree/blob/master/backend/app/views/spree/admin/orders/index.html.erb#L60)
cc: @priyank-gupta 
