### PR TITLE
Optimize any_variants_not_track_inventory? method in product.rb

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -240,10 +240,11 @@ module Spree
     end
 
     def any_variants_not_track_inventory?
+      return true unless Spree::Config.track_inventory_levels
       if variants_including_master.loaded?
         variants_including_master.any? { |v| !v.should_track_inventory? }
       else
-        !Spree::Config.track_inventory_levels || variants_including_master.where(track_inventory: false).exists?
+        variants_including_master.where(track_inventory: false).exists?
       end
     end
 


### PR DESCRIPTION
We don't need to check every variant if there is already Spree::Config.track_inventory_levels is set. The result will remain same as should_track_inventory? also confirms this configuration, but it will prevent the loop.
