### PR TITLE
Update shoulda-matchers and Remove greater than option from quantity

### DIFF
--- a/common_spree_dependencies.rb
+++ b/common_spree_dependencies.rb
@@ -35,7 +35,7 @@ group :test do
   gem 'timecop'
   gem 'with_model'
   gem 'mutant-rspec', '~> 0.8.0'
-  gem 'shoulda-matchers', '~> 3.0'
+  gem 'shoulda-matchers', '~> 3.1'
   gem 'shoulda-callback-matchers', '~> 1.1.1'
 end
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -17,13 +17,9 @@ module Spree
     before_validation :copy_tax_category
 
     validates :variant, presence: true
-    validates :quantity, numericality:
-                        {
-                          only_integer: true,
-                          greater_than: -1,
-                          message: Spree.t('validation.must_be_int')
-                        }
+    validates :quantity, numericality: { only_integer: true, message: Spree.t('validation.must_be_int') }
     validates :price, numericality: true
+
     validates_with Stock::AvailabilityValidator
     validate :ensure_proper_currency
 

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -6,6 +6,10 @@ describe Spree::LineItem, type: :model do
 
   before { create(:store) }
 
+  describe 'Validations' do
+    it { expect(line_item).to validate_numericality_of(:quantity).only_integer.with_message(Spree.t('validation.must_be_int')) }
+  end
+
   describe '#ensure_valid_quantity' do
     context 'quantity.nil?' do
       before do


### PR DESCRIPTION
1. Update shoulda-matchers ~> 3.1 to handle Shoulda::Matchers::ActiveModel::AllowValueMatcher::CouldNotSetAttributeError
2. Remove greater_than option from quantity validation since it is already handled in before validation
