### PR TITLE
Remove unnecessary :after_create callback for Product

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -69,7 +69,6 @@ module Spree
 
     has_many :variant_images, -> { order(:position) }, source: :images, through: :variants_including_master
 
-    after_create :set_master_variant_defaults
     after_create :add_associations_from_prototype
     after_create :build_variants_from_option_values_hash, if: :option_values_hash
 
@@ -322,11 +321,6 @@ module Spree
           self.errors.add(att, error)
         end
       end
-    end
-
-    # ensures the master variant is flagged as such
-    def set_master_variant_defaults
-      master.is_master = true
     end
 
     # Try building a slug based on the following fields in increasing order of specificity.


### PR DESCRIPTION
AFAIK - This callback is not required and may be removed.

This callback was added [here](https://github.com/spree/spree/commit/61ef74651).

Earlier it was required due to a bug in the _spree/core/lib/core/delegate_belongs_to_ - but not needed now - since this was fixed [here](https://github.com/spree/spree/commit/7e1ab357)
