### PR TITLE
Create a preference admin_path and change admin_path getter and setter to make the configuration persistent

### DIFF
--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -22,6 +22,7 @@ module Spree
     # Alphabetized to more easily lookup particular preferences
     preference :address_requires_state, :boolean, default: true # should state/state_name be required
     preference :admin_interface_logo, :string, default: 'logo/spree_50.png'
+    preference :admin_path, :string, default: '/admin'
     preference :admin_products_per_page, :integer, default: 10
     preference :allow_checkout_on_gateway_error, :boolean, default: false
     preference :allow_guest_checkout, :boolean, default: true

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -27,8 +27,13 @@ module Spree
     end
   end
 
-  mattr_accessor :admin_path
-  @@admin_path = "/admin"
+  def self.admin_path
+    Spree::Config[:admin_path]
+  end
+
+  def self.admin_path=(path)
+    Spree::Config[:admin_path] = path
+  end
 
   # Used to configure Spree.
   #

--- a/core/spec/lib/spree/core_spec.rb
+++ b/core/spec/lib/spree/core_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Spree do
+
+  describe '.admin_path' do
+    it { expect(Spree.admin_path).to eq(Spree::Config[:admin_path]) }
+  end
+
+  describe 'admin_path=' do
+    let!(:original_admin_path) { Spree.admin_path }
+    let(:new_admin_path) { '/admin-secret-path' }
+
+    before do
+      Spree.admin_path = new_admin_path
+    end
+
+    it { expect(Spree.admin_path).to eq(new_admin_path) }
+    it { expect(Spree::Config[:admin_path]).to eq(new_admin_path) }
+
+    after do
+      Spree.admin_path = original_admin_path
+    end
+  end
+
+end

--- a/core/spec/models/spree/app_configuration_spec.rb
+++ b/core/spec/models/spree/app_configuration_spec.rb
@@ -19,5 +19,11 @@ describe Spree::AppConfiguration, :type => :model do
     expect(prefs.searcher_class).to eq Spree::Core::Search::Base
   end
 
+  describe 'admin_path' do
+    it { expect(Spree::Config).to have_preference(:admin_path) }
+    it { expect(Spree::Config.preferred_admin_path_type).to eq(:string) }
+    it { expect(Spree::Config.preferred_admin_path_default).to eq('/admin') }
+  end
+
 end
 


### PR DESCRIPTION
Currently, admin_path is saved in a class variable which is set again to '/admin' on restart of the server.

So, we should save it in a preference.
