### PR TITLE
fix toggle icon issue, code optimize, collapsable item triggered on page load

### DIFF
--- a/backend/app/assets/javascripts/spree/backend/admin.js
+++ b/backend/app/assets/javascripts/spree/backend/admin.js
@@ -22,16 +22,33 @@ jQuery(function($) {
     $("span.icon", $(this)).toggleClass("icon-chevron-left");
   });
 
+
+//toggle icon "icon-chevron-down" was asynchronous if clicked rapidly
+//now its stable according to the condition of collapsable dropdown.
   $('#main-sidebar').find('[data-toggle="collapse"]').on('click', function()
     {
-      if($(this).find('.icon-chevron-left').length == 1){
-        $(this).find('.icon-chevron-left').removeClass('icon-chevron-left').addClass('icon-chevron-down');
-      }
-      else {
-        $(this).find('.icon-chevron-down').removeClass('icon-chevron-down').addClass('icon-chevron-left');
-      }
+      var $this = $(this),
+          collapseableItemId = $this.attr('href'),
+          $collapseableElem  = $(collapseableItemId + '.collapse'),
+          $updateElemIcon = $this.find('.icon-chevron-left');
+
+      $collapseableElem.on('show.bs.collapse', function () {
+        $updateElemIcon.removeClass('icon-chevron-left')
+                       .addClass('icon-chevron-down');
+      });
+
+      $collapseableElem.on('hidden.bs.collapse', function () {
+        $updateElemIcon.removeClass('icon-chevron-down')
+                       .addClass('icon-chevron-left');
+      });
     }
-  )
+  );
+
+///// Selected item's collapsable dropdown is opened on page refresh
+////or page load which remained close.
+  $('#main-sidebar').find('.selected').parents('.sidebar-menu-item')
+                    .find('[data-toggle="collapse"]').trigger('click');
+
 
   // Sidebar nav toggle functionality
   var sidebar_toggle = $('#sidebar-toggle');

--- a/backend/app/helpers/spree/admin/navigation_helper.rb
+++ b/backend/app/helpers/spree/admin/navigation_helper.rb
@@ -211,7 +211,7 @@ module Spree
         is_active = url.ends_with?(controller.controller_name) ||
                     url.ends_with?("#{controller.controller_name}/edit") ||
                     url.ends_with?("#{controller.controller_name.singularize}/edit")
-        options.merge!(class: is_active ? 'active' : nil)
+        options.merge!(class: is_active ? 'selected' : nil)
         content_tag(:li, options) do
           link_to(link_text, url)
         end

--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -320,7 +320,7 @@ describe "Products", type: :feature do
 
       it 'should add option_types when selecting a prototype', js: true do
         visit spree.admin_product_path(product)
-        click_link 'Properties'
+        within('#sidebar') { click_link 'Properties' }
         click_link "Select From Prototype"
 
         within("#prototypes tr#row_#{prototype.id}") do

--- a/backend/spec/features/admin/products/properties_spec.rb
+++ b/backend/spec/features/admin/products/properties_spec.rb
@@ -82,7 +82,7 @@ describe "Properties", type: :feature, js: true do
       create(:product)
       visit spree.admin_products_path
       click_icon :edit
-      click_link "Properties"
+      within('#sidebar') { click_link "Properties" }
     end
 
     # Regression test for #2279
@@ -122,7 +122,7 @@ describe "Properties", type: :feature, js: true do
       fill_in "product_product_properties_attributes_0_property_name", with: "A Property"
       fill_in "product_product_properties_attributes_0_value", with: "A Value"
       click_button "Update"
-      click_link "Properties"
+      within('#sidebar') { click_link "Properties" }
     end
 
     def delete_product_property
@@ -132,7 +132,7 @@ describe "Properties", type: :feature, js: true do
     end
 
     def check_property_row_count(expected_row_count)
-      click_link "Properties"
+      within('#sidebar') { click_link "Properties" }
       expect(page).to have_css("tbody#product_properties")
       expect(all("tbody#product_properties tr").count).to eq(expected_row_count)
     end


### PR DESCRIPTION
Toggle icon "icon-chevron-down"/"icon-chevron-left"  were asynchronous if clicked rapidly now its stable according to the condition of collapsable dropdown and some jquery code optimization also.

Selected item's collapsable dropdown is opened on page refresh or page load which remained close.
