### PR TITLE
Fix n+1 queries in frontend app - HomeController#index for promotions

### DIFF
--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -36,6 +36,9 @@ module Spree
     has_many :product_promotion_rules, class_name: 'Spree::ProductPromotionRule'
     has_many :promotion_rules, through: :product_promotion_rules, class_name: 'Spree::PromotionRule'
 
+    has_many :promotions, through: :promotion_rules, class_name: 'Spree::Promotion'
+    has_many :possible_promotions, ->{ advertised.active }, through: :promotion_rules, class_name: 'Spree::Promotion', source: :promotion
+
     belongs_to :tax_category, class_name: 'Spree::TaxCategory'
     belongs_to :shipping_category, class_name: 'Spree::ShippingCategory', inverse_of: :products
 
@@ -209,11 +212,6 @@ module Spree
         product_property.value = property_value
         product_property.save!
       end
-    end
-
-    def possible_promotions
-      promotion_ids = promotion_rules.map(&:promotion_id).uniq
-      Spree::Promotion.advertised.where(id: promotion_ids).reject(&:expired?)
     end
 
     def total_on_hand

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -34,12 +34,9 @@ module Spree
         ON spree_order_promotions.promotion_id = #{table_name}.id
       SQL
     }
+    scope :advertised, ->{ where(advertise: true) }
 
     self.whitelisted_ransackable_attributes = ['path', 'promotion_category_id', 'code']
-
-    def self.advertised
-      where(advertise: true)
-    end
 
     def self.with_coupon_code(coupon_code)
       where("lower(#{table_name}.code) = ?", coupon_code.strip.downcase).first

--- a/frontend/app/controllers/spree/home_controller.rb
+++ b/frontend/app/controllers/spree/home_controller.rb
@@ -5,7 +5,7 @@ module Spree
 
     def index
       @searcher = build_searcher(params.merge(include_images: true))
-      @products = @searcher.retrieve_products
+      @products = @searcher.retrieve_products.includes(:possible_promotions)
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
   end

--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -10,7 +10,7 @@ module Spree
 
     def index
       @searcher = build_searcher(params.merge(include_images: true))
-      @products = @searcher.retrieve_products
+      @products = @searcher.retrieve_products.includes(:possible_promotions)
       @taxonomies = Spree::Taxonomy.includes(root: :children)
     end
 


### PR DESCRIPTION
In the frontend app - on main homepage (HomeController#index) - there are a couple of promotion_rule and promotion queries being fired for each Spree::Product. The reason can be found [here](https://github.com/vinsol/spree/blob/master/core/app/helpers/spree/products_helper.rb#L62).

Fixed it by making the _promotions_ a through relation on Spree::Product so that it can be eager-loaded.

Another change: In Spree::Promotion - .advertised should actually be scope. :P

**PS** - Will add specs once the PR is approved for merge :smile: 
