### PR TITLE
admin should not be available to order unavailable products

### DIFF
--- a/core/app/models/spree/stock/quantifier.rb
+++ b/core/app/models/spree/stock/quantifier.rb
@@ -1,7 +1,7 @@
 module Spree
   module Stock
     class Quantifier
-      attr_reader :stock_items
+      attr_reader :stock_items, :variant
 
       def initialize(variant)
         @variant = variant
@@ -9,7 +9,7 @@ module Spree
       end
 
       def total_on_hand
-        if @variant.should_track_inventory?
+        if variant.should_track_inventory?
           stock_items.sum(:count_on_hand)
         else
           Float::INFINITY
@@ -21,7 +21,7 @@ module Spree
       end
 
       def can_supply?(required = 1)
-        total_on_hand >= required || backorderable?
+        variant.available? && (total_on_hand >= required || backorderable?)
       end
 
     end

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -64,6 +64,10 @@ module Spree
     self.whitelisted_ransackable_associations = %w[option_values product prices default_price]
     self.whitelisted_ransackable_attributes = %w[weight sku]
 
+    def available?
+      !discontinued? && product.available?
+    end
+
     def self.active(currency = nil)
       not_discontinued.joins(:prices).where(deleted_at: nil).where('spree_prices.currency' => currency || Spree::Config[:currency]).where('spree_prices.amount IS NOT NULL')
     end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -14,7 +14,7 @@ module Spree
       let(:product) do
         product = Spree::Product.create(name: 'Test',
                                         sku: 'TEST-1',
-                                        price: 33.22)
+                                        price: 33.22, available_on: Time.current - 1.day)
         product.shipping_category = create(:shipping_category)
         product.save
         product

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -543,6 +543,53 @@ describe Spree::Variant, :type => :model do
     end
   end
 
+  describe "#available?" do
+    let(:variant) { create(:variant) }
+    context 'when discontinued' do
+      before(:each) do
+        variant.discontinue_on = Time.current - 1.day
+      end
+
+      context 'when product is available' do
+        before(:each) do
+          allow(variant.product).to receive(:available?) { true }
+        end
+
+        it { expect(variant.available?).to be(false) }
+      end
+
+      context 'when product is not available' do
+        before(:each) do
+          allow(variant.product).to receive(:available?) { false }
+        end
+
+        it { expect(variant.available?).to be(false) }
+      end
+    end
+
+    context 'when not discontinued' do
+      before(:each) do
+        variant.discontinue_on = Time.current + 1.day
+      end
+
+      context 'when product is available' do
+        before(:each) do
+          allow(variant.product).to receive(:available?) { true }
+        end
+
+        it { expect(variant.available?).to be(true) }
+      end
+
+      context 'when product is not available' do
+        before(:each) do
+          allow(variant.product).to receive(:available?) { false }
+        end
+
+        it { expect(variant.available?).to be(false) }
+      end
+    end
+  end
+
   describe "#check_price" do
     let(:variant) { create(:variant) }
     let(:variant2) { create(:variant) }


### PR DESCRIPTION
Admin can view unavailable product but should not be able to place order for the same.
Product will be shown as 'out of stock' when admin is viewing an unavailable product.

Fixes issue 4754.
