### PR TITLE
Add user check when not guest checkout - Fix #4769

### DIFF
--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -20,23 +20,175 @@ describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
       allow(Spree::Order).to receive_message_chain(:friendly, :find).and_return(order)
     end
 
-    context "#update" do
-      it "does refresh the shipment rates with all shipping methods" do
-        allow(order).to receive_messages(update_attributes: true)
-        allow(order).to receive_messages(next: false)
-        allow(order).to receive_messages(complete?: true)
-        expect(order).to receive(:refresh_shipment_rates)
-          .with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
-        attributes = {
+    describe '#update' do
+      let(:attributes) {
+        {
           order_id: order.number,
           order: {
             email: "",
             use_billing: "",
             bill_address_attributes: {},
             ship_address_attributes: {}
-          }
+          },
+          guest_checkout: 'true'
         }
-        spree_put :update, attributes
+      }
+
+      def send_request(params = {})
+        spree_put :update, params
+      end
+
+      context 'using guest checkout' do
+        context 'having valid parameters' do
+          before do
+            allow(order).to receive_messages(update_attributes: true)
+            allow(order).to receive_messages(next: false)
+            allow(order).to receive_messages(complete?: true)
+            allow(order).to receive_messages(refresh_shipment_rates: true)
+          end
+
+          context 'having successful response' do
+            before { send_request(attributes) }
+            it { expect(response).to have_http_status(302) }
+            it { expect(response).to redirect_to(edit_admin_order_url(order)) }
+          end
+
+          context 'with correct method flow' do
+            it { expect(order).to receive(:update_attributes).with(attributes[:order]) }
+            it { expect(order).to_not receive(:next) }
+            it { expect(order).to receive(:complete?) }
+            it 'does refresh the shipment rates with all shipping methods' do
+              expect(order).to receive(:refresh_shipment_rates)
+              .with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+            end
+            it { expect(controller).to receive(:load_order).and_call_original }
+            it { expect(controller).to receive(:guest_checkout?).twice.and_call_original }
+            it { expect(controller).to_not receive(:load_user).and_call_original }
+            after { send_request(attributes) }
+          end
+        end
+
+        context 'having invalid parameters' do
+          before do
+            allow(order).to receive_messages(update_attributes: false)
+          end
+
+          context 'having failure response' do
+            before { send_request(attributes) }
+            it { expect(response).to render_template(:edit) }
+          end
+
+          context 'with correct method flow' do
+            it { expect(order).to receive(:update_attributes).with(attributes[:order]) }
+            it { expect(controller).to receive(:load_order).and_call_original }
+            it { expect(controller).to receive(:guest_checkout?).and_call_original }
+            it { expect(controller).to_not receive(:load_user).and_call_original }
+            after { send_request(attributes) }
+          end
+        end
+      end
+
+      context 'without using guest checkout' do
+        let (:user) { mock_model(Spree.user_class) }
+        let (:_attributes) { attributes.merge(guest_checkout: 'false', user_id: user.id) }
+
+        context 'having valid parameters' do
+          before do
+            allow(Spree.user_class).to receive(:find_by).and_return(user)
+            allow(order).to receive_messages(update_attributes: true)
+            allow(order).to receive_messages(next: false)
+            allow(order).to receive_messages(complete?: true)
+            allow(order).to receive_messages(refresh_shipment_rates: true)
+            allow(order).to receive_messages(associate_user!: true)
+            allow(controller).to receive(:guest_checkout?).and_return(false)
+            allow(order).to receive(:associate_user!)
+          end
+
+          context 'having successful response' do
+            before { send_request(_attributes) }
+            it { expect(response).to have_http_status(302) }
+            it { expect(response).to redirect_to(edit_admin_order_url(order)) }
+          end
+
+          context 'with correct method flow' do
+            it { expect(order).to receive(:update_attributes).with(_attributes[:order]) }
+            it { expect(order).to receive(:associate_user!).with(user, order.email.blank?) }
+            it { expect(order).to_not receive(:next) }
+            it { expect(order).to receive(:complete?) }
+            it 'does refresh the shipment rates with all shipping methods' do
+              expect(order).to receive(:refresh_shipment_rates)
+              .with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+            end
+            it { expect(controller).to receive(:load_order).and_call_original }
+            it { expect(controller).to receive(:guest_checkout?).twice.and_call_original }
+            it { expect(controller).to receive(:load_user).and_call_original }
+            after { send_request(_attributes) }
+          end
+        end
+
+        context 'having invalid parameters' do
+          before do
+            allow(Spree.user_class).to receive(:find_by).and_return(false)
+            allow(controller).to receive(:guest_checkout?).and_return(false)
+          end
+
+          context 'having failure response' do
+            before { send_request(_attributes) }
+            it { expect(response).to render_template(:edit) }
+          end
+
+          context 'with correct method flow' do
+            it { expect(order).to_not receive(:update_attributes).with(_attributes[:order]) }
+            it { expect(controller).to receive(:load_order).and_call_original }
+            it { expect(controller).to receive(:guest_checkout?).and_call_original }
+            it { expect(controller).to receive(:load_user).and_call_original }
+            after { send_request(_attributes) }
+          end
+        end
+
+        describe '#load_user' do
+          context 'having valid parameters' do
+            before do
+              allow(Spree.user_class).to receive(:find_by).and_return(user)
+              allow(order).to receive_messages(update_attributes: true)
+              allow(order).to receive_messages(next: false)
+              allow(order).to receive_messages(complete?: true)
+              allow(order).to receive_messages(refresh_shipment_rates: true)
+              allow(order).to receive_messages(associate_user!: true)
+              allow(controller).to receive(:guest_checkout?).and_return(false)
+              allow(order).to receive(:associate_user!)
+            end
+
+            it "expects to assign user" do
+              send_request(_attributes)
+              expect(assigns[:user]).to eq(user)
+            end
+
+            context 'with correct method flow' do
+              it { expect(Spree.user_class).to receive(:find_by).with(id: user.id.to_s).and_return(user) }
+              after { send_request(_attributes) }
+            end
+          end
+
+          context 'with invalid parameters' do
+            before do
+              allow(Spree.user_class).to receive(:find_by).and_return(nil)
+              allow(controller).to receive(:guest_checkout?).and_return(false)
+            end
+
+            it "expects to not assign user" do
+              send_request(_attributes)
+              expect(assigns[:user]).to_not eq(user)
+            end
+
+            context 'with correct method flow' do
+              it { expect(Spree.user_class).to receive(:find_by).with(id: user.id.to_s).and_return(nil) }
+              it { expect(Spree.user_class).to receive(:find_by).with(email: _attributes[:order][:email])
+                .and_return(nil) }
+              after { send_request(_attributes) }
+            end
+          end
+        end
       end
     end
   end

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -40,6 +40,7 @@ describe "Customer Details", type: :feature, js: true do
 
   context "brand new order" do
     before do
+      allow(Spree.user_class).to receive(:find_by).and_return(user)
       visit spree.new_admin_order_path
     end
     # Regression test for #3335 & #5317
@@ -63,7 +64,7 @@ describe "Customer Details", type: :feature, js: true do
       expect_form_value('#order_bill_address_attributes_state_id', user.bill_address.state_id.to_s)
       expect_form_value('#order_bill_address_attributes_phone', user.bill_address.phone)
       click_button "Update"
-      expect(Spree::Order.last.user).not_to be_nil
+      expect(Spree::Order.last.user).to eq(user)
     end
   end
 
@@ -74,6 +75,7 @@ describe "Customer Details", type: :feature, js: true do
         config.company = true
       end
 
+      allow(Spree.user_class).to receive(:find_by).and_return(user)
       visit spree.admin_orders_path
       within('table#listing_orders') { click_icon(:edit) }
     end
@@ -123,9 +125,9 @@ describe "Customer Details", type: :feature, js: true do
       previous_user = order.user
       click_link "Customer"
       fill_in "order_email", with: "newemail@example.com"
-      expect { click_button "Update" }.to change { order.reload.email }.to "newemail@example.com"
       expect(order.user_id).to eq previous_user.id
       expect(order.user.email).to eq previous_user.email
+      expect { click_button "Update" }.to change { order.reload.email }.to "newemail@example.com"
     end
 
     context "country associated was removed" do

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -11,6 +11,7 @@ describe "New Order", :type => :feature do
 
   before do
     # create default store
+    allow(Spree.user_class).to receive(:find_by).and_return(user)
     create(:store)
     visit spree.new_admin_order_path
   end
@@ -132,6 +133,7 @@ describe "New Order", :type => :feature do
   # Regression test for #5327
   context "customer with default credit card", js: true do
     before do
+      allow(Spree.user_class).to receive(:find_by).and_return(user)
       create(:credit_card, default: true, user: user)
     end
     it "transitions to delivery not to complete" do


### PR DESCRIPTION
Adds a check for user load(by id/email) before updating customer details when not using guest checkout.
