### PR TITLE
Remove Spree.admin_path=, spree.js.coffee.erb and backend.js to use Spree.admin_path in it

### DIFF
--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -50,24 +50,24 @@
 //= require spree/backend/variant_management
 //= require spree/backend/zone
 
-Spree.routes.clear_cache = Spree.pathFor('admin/general_settings/clear_cache')
+Spree.routes.clear_cache = Spree.adminPathFor('general_settings/clear_cache')
 Spree.routes.checkouts_api = Spree.pathFor('api/v1/checkouts')
 Spree.routes.classifications_api = Spree.pathFor('api/v1/classifications')
 Spree.routes.option_type_search = Spree.pathFor('api/v1/option_types')
 Spree.routes.option_value_search = Spree.pathFor('api/v1/option_values')
 Spree.routes.orders_api = Spree.pathFor('api/v1/orders')
 Spree.routes.products_api = Spree.pathFor('api/v1/products')
-Spree.routes.product_search = Spree.pathFor('admin/search/products')
+Spree.routes.product_search = Spree.adminPathFor('search/products')
 Spree.routes.shipments_api = Spree.pathFor('api/v1/shipments')
 Spree.routes.checkouts_api = Spree.pathFor('api/v1/checkouts')
 Spree.routes.stock_locations_api = Spree.pathFor('api/v1/stock_locations')
 Spree.routes.taxon_products_api = Spree.pathFor('api/v1/taxons/products')
 Spree.routes.taxons_search = Spree.pathFor('api/v1/taxons')
-Spree.routes.user_search = Spree.pathFor('admin/search/users')
+Spree.routes.user_search = Spree.adminPathFor('search/users')
 Spree.routes.variants_api = Spree.pathFor('api/v1/variants')
 
 Spree.routes.edit_product = function(product_id) {
-  return Spree.pathFor('admin/products/' + product_id + '/edit')
+  return Spree.adminPathFor('products/' + product_id + '/edit')
 }
 
 Spree.routes.payments_api = function(order_id) {

--- a/core/app/assets/javascripts/spree.js.coffee.erb
+++ b/core/app/assets/javascripts/spree.js.coffee.erb
@@ -10,9 +10,15 @@ class window.Spree
   @mountedAt: ->
     "<%= Rails.application.routes.url_helpers.spree_path(trailing_slash: true) %>"
 
+  @adminPath: ->
+    "<%= Spree.admin_path %>"
+
   @pathFor: (path) ->
     locationOrigin = "#{window.location.protocol}//#{window.location.hostname}" + (if window.location.port then ":#{window.location.port}" else "")
     @url("#{locationOrigin}#{@mountedAt()}#{path}", @url_params).toString()
+
+  @adminPathFor: (path) ->
+    @pathFor("#{@adminPath()}#{path}")
 
   # Helper function to take a URL and add query parameters to it
   # Uses the JSUri library from here: https://github.com/derek-watson/jsUri

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -31,6 +31,13 @@ module Spree
     Spree::Config[:admin_path]
   end
 
+  # Used to configure admin_path for Spree
+  #
+  # Example:
+  #
+  # write the following line in `config/initializers/spree.rb`
+  #   Spree.admin_path = 'custom-path/'
+
   def self.admin_path=(path)
     Spree::Config[:admin_path] = path
   end


### PR DESCRIPTION
Remove admin_path= from Spree because admin_path= won't effect when changed dynamically. We need to restart the server after changing this configuration.
