### PR TITLE
Fixes #6642, create a new promotion action create_adjusted_line_items

### DIFF
--- a/backend/app/views/spree/admin/promotions/actions/_create_adjusted_line_items.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_adjusted_line_items.html.erb
@@ -1,0 +1,52 @@
+<div class="panel-body calculator-fields">
+  <% promotion_action.promotion_action_line_items.each do |item| %>
+    <strong><%= item.quantity %> x <%= item.variant.product.name %></strong>
+    <%= item.variant.options_text %>
+  <% end %>
+
+  <% if promotion_action.promotion_action_line_items.empty? %>
+    <% line_items = promotion_action.promotion_action_line_items %>
+    <% line_items.build %>
+
+    <% line_items.each_with_index do |line_item, index| %>
+      <div class="add-line-item">
+        <% line_item_prefix = "#{param_prefix}[promotion_action_line_items_attributes][#{index}]" %>
+        <div class="form-group">
+          <%= label_tag "#{line_item_prefix}_variant_id", Spree.t(:variant) %>
+          <%= hidden_field_tag "#{line_item_prefix}[variant_id]", line_item.variant_id, class: "variant_autocomplete fullwidth-input" %>
+        </div>
+        <div class="form-group no-marginb">
+          <%= label_tag "#{line_item_prefix}_quantity", Spree.t(:quantity) %>
+          <%= number_field_tag "#{line_item_prefix}[quantity]", line_item.quantity, min: 1, class: 'form-control' %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+
+  <div class="row no-marginb">
+    <div class="form-group col-md-6 no-marginb">
+      <% field_name = "#{param_prefix}[calculator_type]" %>
+      <%= label_tag field_name, Spree.t(:calculator) %>
+      <%= select_tag field_name,
+                    options_from_collection_for_select(Spree::Promotion::Actions::CreateItemAdjustments.calculators, :to_s, :description, promotion_action.calculator.type),
+                    class: 'type-select select2' %>
+    </div>
+    <% unless promotion_action.new_record? %>
+      <div class="form-group col-md-6 no-marginb settings">
+        <% promotion_action.calculator.preferences.keys.map do |key| %>
+          <% field_name = "#{param_prefix}[calculator_attributes][preferred_#{key}]" %>
+          <%= label_tag field_name, Spree.t(key.to_s) %>
+          <%= preference_field_tag(field_name,
+                                   promotion_action.calculator.get_preference(key),
+                                   type: promotion_action.calculator.preference_type(key)) %>
+        <% end %>
+        <%= hidden_field_tag "#{param_prefix}[calculator_attributes][id]", promotion_action.calculator.id %>
+      </div>
+    <% end %>
+  </div>
+  <% if promotion_action.calculator.respond_to?(:preferences) %>
+    <div class="alert alert-info js-warning margint no-marginb">
+      <%= Spree.t(:calculator_settings_warning) %>
+    </div>
+  <% end %>
+</div>

--- a/core/app/models/spree/promotion/actions/create_adjusted_line_items.rb
+++ b/core/app/models/spree/promotion/actions/create_adjusted_line_items.rb
@@ -1,0 +1,74 @@
+module Spree
+  class Promotion
+    module Actions
+      class CreateAdjustedLineItems < CreateLineItems
+        include Spree::CalculatedAdjustments
+        include Spree::AdjustmentSource
+
+        before_validation -> { self.calculator ||= Calculator::PercentOnLineItem.new }
+
+        # Adds a line item with its discount to the Order if the promotion is eligible
+        #
+        #
+        # e.g.
+        #   - A promo adds a line item to cart if order total greater then $30
+        #   - Customer add 1 item of $10 to cart and specifies a 50% discount on it.
+        #   - This action shouldn't perform because the order is not eligible
+        #   - Customer increases item quantity to 5 (order total goes to $50)
+        #   - Now the order is eligible for the promo and the action should perform
+        #   - Now cart contains 5 $10 items and 1 promotional item for $5. So total is $55.
+        #
+        # Another complication is when the same line item created by the promo
+        # is also added to cart on a separate action.
+        #
+        # e.g.
+        #   - Promo adds 1 item A to cart if order total greater then $30
+        #   - Customer add 2 items B to cart, current order total is $40
+        #   - This action performs adding item A to cart since order is eligible
+        #   - Customer changes his mind and updates item B quantity to 1
+        #   - At this point order is no longer eligible and one might expect
+        #     that item A should be removed
+        #
+        # It doesn't remove items from the order here because there's no way
+        # it can know whether that item was added via this promo action or if
+        # it was manually populated somewhere else, but the promotion discount
+        # on the order is removed. If the user needs to remove the promotional line items
+        # It can be removed manually.
+        def perform(options = {})
+          order = options[:order]
+
+          promotion_action_line_items.map do |item|
+            add_line_item(order, item, order.quantity_of(item.variant))
+          end.any? | create_unique_adjustments(order, order.line_items)
+        end
+
+        def compute_amount(line_item)
+          return 0 unless promotion.line_item_actionable?(line_item.order, line_item)
+          return 0 unless promotion_action_line_items_include?(line_item)
+          [line_item.amount, compute(line_item)].min * -1 * amount_adjustment_factor(line_item)
+        end
+
+        private
+
+          def amount_adjustment_factor(line_item)
+            [promotion_action_line_item_for(line_item).quantity, line_item.quantity].min.to_f / line_item.quantity
+          end
+
+          def promotion_action_line_items_include?(line_item)
+            line_item && promotion_action_line_item_for(line_item)
+          end
+
+          def promotion_action_line_item_for(line_item)
+            promotion_action_line_items.detect { |item| item.variant_id == line_item.variant_id }
+          end
+
+          def add_line_item(order, item, current_quantity)
+            if current_quantity < item.quantity && item_available?(item)
+              line_item = order.contents.add(item.variant, item.quantity - current_quantity)
+              line_item.try(:valid?)
+            end
+          end
+      end
+    end
+  end
+end

--- a/core/lib/spree/core/engine.rb
+++ b/core/lib/spree/core/engine.rb
@@ -93,6 +93,7 @@ module Spree
           Promotion::Actions::CreateAdjustment,
           Promotion::Actions::CreateItemAdjustments,
           Promotion::Actions::CreateLineItems,
+          Promotion::Actions::CreateAdjustedLineItems,
           Promotion::Actions::FreeShipping]
       end
 

--- a/core/spec/models/spree/promotion/actions/create_adjusted_line_item_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjusted_line_item_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+
+describe Spree::Promotion::Actions::CreateAdjustedLineItems, type: :model do
+  let(:order) { create(:order) }
+  let(:promotion) {Spree::Promotion.create(name: 'Free Line Item') }
+  let(:action) { Spree::Promotion::Actions::CreateAdjustedLineItems.create(promotion: promotion) }
+  let(:shirt) { create(:variant) }
+  let(:mug) { create(:variant) }
+  let(:payload) { { order: order } }
+  let(:promotional_quantity) { 2 }
+  let(:calculator) { action.calculator }
+
+  def empty_stock(variant)
+    variant.stock_items.update_all(backorderable: false)
+    variant.stock_items.each(&:reduce_count_on_hand_to_zero)
+  end
+
+  describe "#perform" do
+    before do
+      action.promotion_action_line_items.create!(
+        variant: shirt,
+        quantity: 2
+      )
+    end
+
+    context 'order is eligible' do
+      context 'promotional line item not present' do
+        subject { order.line_items.find_by_variant_id(shirt.id) }
+
+        context 'line item amount is less than computed discount' do
+          before do
+            calculator.preferred_percent = 10.0
+            calculator.save
+            action.perform(payload)
+            order.update_totals
+          end
+
+          it { expect(subject.quantity).to eq(promotional_quantity) }
+          it { expect(subject.promo_total).to eq(calculator.compute(subject).round(2) * -1) }
+        end
+
+        context 'line item amount is more than computed discount' do
+          before do
+            calculator.preferred_percent = 110.0
+            calculator.save
+            action.perform(payload)
+            order.update_totals
+          end
+
+          it { expect(subject.quantity).to eq(promotional_quantity) }
+          it { expect(subject.promo_total).to eq(subject.amount.round(2) * -1) }
+        end
+      end
+
+      context 'promotional line item quantity is less than promotion quantity' do
+        let(:current_quantity) { promotional_quantity - 1 }
+
+        before do
+          order.contents.add(shirt, current_quantity)
+        end
+
+        subject { order.line_items.find_by_variant_id(shirt.id) }
+
+        context 'line item amount is less than computed discount' do
+          before do
+            calculator.preferred_percent = 10.0
+            calculator.save
+            action.perform(payload)
+            order.update_totals
+          end
+
+          it { expect(subject.quantity).to eq(promotional_quantity) }
+          it { expect(subject.promo_total).to eq(calculator.compute(subject).round(2) * -1) }
+        end
+
+        context 'line item amount is more than computed discount' do
+          before do
+            calculator.preferred_percent = 110.0
+            calculator.save
+            action.perform(payload)
+            order.update_totals
+          end
+
+          it { expect(subject.quantity).to eq(promotional_quantity) }
+          it { expect(subject.promo_total).to eq(subject.amount.round(2) * -1) }
+        end
+      end
+
+      context 'promotional line item quantity is more than promotion quantity' do
+        let(:current_quantity) { promotional_quantity + 1 }
+
+        before do
+          order.contents.add(shirt, current_quantity)
+        end
+
+        subject { order.line_items.find_by_variant_id(shirt.id) }
+
+        context 'line item amount is less than computed discount' do
+          before do
+            calculator.preferred_percent = 10.0
+            calculator.save
+            action.perform(payload)
+            order.update_totals
+          end
+
+          it { expect(subject.quantity).to eq(current_quantity) }
+          it { expect(subject.promo_total).to eq(calculator.compute(subject).round(2) * -1 * promotional_quantity / subject.quantity) }
+        end
+
+        context 'line item amount is more than computed discount' do
+          before do
+            calculator.preferred_percent = 110.0
+            calculator.save
+            action.perform(payload)
+            order.update_totals
+          end
+
+          it { expect(subject.quantity).to eq(current_quantity) }
+          it { expect(subject.promo_total).to eq(subject.amount.round(2) * -1 * promotional_quantity / subject.quantity) }
+        end
+      end
+
+      context 'variant out of stock' do
+        before do
+          empty_stock(shirt)
+          action.perform(payload)
+          order.update_totals
+        end
+
+        subject { order.line_items.find_by_variant_id(mug.id) }
+
+        it { expect(subject).to be_nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Current CreateLineItems action is not much useful, because if someone wants to add a line_item to a cart, user can add its himself. There is no use of adding a promotional variant to an order with its actual price.

The CreateAdjustedLineItems allows you to specify calculator and its adjustment price or percentage with it. So if an variant costs $20 and 50% discount is specified on it, it is added to the cart for $10 when the promotion is applied to it.
