### PR TITLE
Add missing user_id forign_key to promotion_rule_users association si…

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -11,7 +11,7 @@ module Spree
       has_many :role_users, class_name: 'Spree::RoleUser', foreign_key: :user_id
       has_many :spree_roles, through: :role_users, class_name: 'Spree::Role', source: :role
 
-      has_many :promotion_rule_users, class_name: 'Spree::PromotionRuleUser'
+      has_many :promotion_rule_users, class_name: 'Spree::PromotionRuleUser', foreign_key: :user_id
       has_many :promotion_rules, through: :promotion_rule_users, class_name: 'Spree::PromotionRule'
 
       has_many :orders, foreign_key: :user_id, class_name: "Spree::Order"

--- a/core/spec/models/spree/concerns/user_methods_spec.rb
+++ b/core/spec/models/spree/concerns/user_methods_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe Spree::UserMethods do
   let(:test_user) { create :user }
 
+  describe 'Associations' do
+    subject { test_user }
+    it { is_expected.to have_many(:promotion_rule_users).with_foreign_key(:user_id).class_name('Spree::PromotionRuleUser') }
+  end
+
   describe '#has_spree_role?' do
     subject { test_user.has_spree_role? name }
 


### PR DESCRIPTION
…nce it used to search legacy_user_id which doesn't exists
