### PR TITLE
Add alias of can_go_to_state? in checkout.rb and use it in checkout_controller.rb

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -216,6 +216,8 @@ module Spree
             checkout_step_index(state) > checkout_step_index(self.state)
           end
 
+          alias :future_state? :can_go_to_state?
+
           define_callbacks :updating_from_params, terminator: ->(_target, result) { result == false }
 
           set_callback :updating_from_params, :before, :update_params_payment_source

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -101,7 +101,7 @@ module Spree
 
     def set_state_if_present
       if params[:state]
-        if @order.can_go_to_state?(params[:state]) && !skip_state_validation?
+        if @order.future_state?(params[:state]) && !skip_state_validation?
           redirect_to checkout_state_path(@order.state)
         end
         @order.state = params[:state]


### PR DESCRIPTION
Use of can_go_to_state? in checkout controller is quite confusing. So, A new alias is created - future_state?

Please refer - https://github.com/spree/spree/issues/6589. 
