### PR TITLE
remove pagination for zero records found and save a count query

### DIFF
--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -145,9 +145,9 @@
 
 <% end %>
 
-<%= render 'spree/admin/shared/index_table_options', collection: @orders %>
 
 <% if @orders.any? %>
+  <%= render 'spree/admin/shared/index_table_options', collection: @orders %>
   <table class="table" id="listing_orders" data-hook>
     <thead>
       <tr data-hook="admin_orders_index_headers">
@@ -214,6 +214,7 @@
     <% end %>
     </tbody>
   </table>
+  <%= render 'spree/admin/shared/index_table_options', collection: @orders, simple: true %>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Order)) %>,
@@ -221,4 +222,3 @@
   </div>
 <% end %>
 
-<%= render 'spree/admin/shared/index_table_options', collection: @orders, simple: true %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -48,9 +48,9 @@
   </div>
 <% end %>
 
-<%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection } %>
 
 <% if @collection.any? %>
+  <%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection } %>
   <table class="table" id="listing_products">
     <thead>
       <tr data-hook="admin_products_index_headers">
@@ -81,6 +81,7 @@
       <% end %>
     </tbody>
   </table>
+  <%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection } %>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Product)) %>,
@@ -88,4 +89,3 @@
   </div>
 <% end %>
 
-<%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection } %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -42,9 +42,9 @@
   </div>
 <% end %>
 
-<%= paginate @promotions %>
 
 <% if @promotions.any? %>
+  <%= paginate @promotions %>
   <table class="table">
     <thead>
       <tr>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -58,6 +58,7 @@
       <% end %>
     </tbody>
   </table>
+  <%= paginate @collection %>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Property)) %>,
@@ -65,4 +66,3 @@
   </div>
 <% end %>
 
-<%= paginate @collection %>

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -8,31 +8,32 @@
 <% end %>
 
 <% if @stock_movements.any? %>
-<table class="table" id='listing_stock_movements'>
-  <colgroup>
-    <col style="width: 35%">
-    <col style="width: 20%">
-    <col style="width: 45%">
-  </colgroup>
-  <thead>
-    <tr data-hook="admin_stock_movements_index_headers">
-      <th><%= Spree.t(:stock_item) %>
-      <th><%= Spree.t(:quantity) %></th>
-      <th><%= Spree.t(:action) %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @stock_movements.each do |stock_movement|%>
-      <tr id="<%= spree_dom_id stock_movement %>" data-hook="admin_stock_movements_index_rows">
-        <td>
-          <%= display_variant(stock_movement) %>
-        </td>
-        <td><%= stock_movement.quantity %></td>
-        <td><%= pretty_originator(stock_movement) %></td>
+  <table class="table" id='listing_stock_movements'>
+    <colgroup>
+      <col style="width: 35%">
+      <col style="width: 20%">
+      <col style="width: 45%">
+    </colgroup>
+    <thead>
+      <tr data-hook="admin_stock_movements_index_headers">
+        <th><%= Spree.t(:stock_item) %>
+        <th><%= Spree.t(:quantity) %></th>
+        <th><%= Spree.t(:action) %></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @stock_movements.each do |stock_movement|%>
+        <tr id="<%= spree_dom_id stock_movement %>" data-hook="admin_stock_movements_index_rows">
+          <td>
+            <%= display_variant(stock_movement) %>
+          </td>
+          <td><%= stock_movement.quantity %></td>
+          <td><%= pretty_originator(stock_movement) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <%= paginate @stock_movements %>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::StockMovement)) %>,
@@ -40,4 +41,3 @@
   </div>
 <% end %>
 
-<%= paginate @stock_movements %>

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -72,6 +72,7 @@
       <% end %>
     </tbody>
   </table>
+  <%= paginate @stock_transfers %>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::StockTransfer)) %>,
@@ -79,4 +80,3 @@
   </div>
 <% end %>
 
-<%= paginate @stock_transfers %>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -34,6 +34,7 @@
       <% end %>
     </tbody>
   </table>
+  <%= paginate @zones %>
 <% else %>
   <div class="alert alert-info no-objects-found">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Zone)) %>,
@@ -41,4 +42,3 @@
   </div>
 <% end %>
 
-<%= paginate @zones %>


### PR DESCRIPTION
On admin end in every listing, if zero records are found then pagination is removed and a count query is also saved due to pagination removal
