### PR TITLE
Use `present?` instead of `any?` to save one count query

### DIFF
--- a/backend/app/views/spree/admin/customer_returns/index.html.erb
+++ b/backend/app/views/spree/admin/customer_returns/index.html.erb
@@ -11,8 +11,7 @@
 <% end %>
 
 <% if @order.shipments.any?(&:shipped?) %>
-
-  <% if @customer_returns.any? %>
+  <% if @customer_returns.present? %>
     <table class="table">
       <thead data-hook="customer_return_header">
         <tr>

--- a/backend/app/views/spree/admin/images/index.html.erb
+++ b/backend/app/views/spree/admin/images/index.html.erb
@@ -6,7 +6,7 @@
 
 <% has_variants = @product.has_variants? %>
 
-<% unless @product.variant_images.any? %>
+<% unless @product.variant_images.present? %>
   <div class="alert alert-warning">
     <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Image)) %>.
   </div>

--- a/backend/app/views/spree/admin/option_types/index.html.erb
+++ b/backend/app/views/spree/admin/option_types/index.html.erb
@@ -10,7 +10,7 @@
 
 <div id="new_option_type"></div>
 
-<% if @option_types.any? %>
+<% if @option_types.present? %>
 <table class="table sortable" id="listing_option_types" data-hook data-sortable-link="<%= update_positions_admin_option_types_url %>">
   <thead>
     <tr data-hook="option_header">

--- a/backend/app/views/spree/admin/orders/index.html.erb
+++ b/backend/app/views/spree/admin/orders/index.html.erb
@@ -147,7 +147,7 @@
 
 <%= render 'spree/admin/shared/index_table_options', collection: @orders %>
 
-<% if @orders.any? %>
+<% if @orders.present? %>
   <table class="table" id="listing_orders" data-hook>
     <thead>
       <tr data-hook="admin_orders_index_headers">

--- a/backend/app/views/spree/admin/payment_methods/index.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_payment_method), new_object_url, :class => "btn-success", :icon => 'add', :id => 'admin_new_payment_methods_link' %>
 <% end if can? :create, Spree::PaymentMethod %>
 
-<% if @payment_methods.any? %>
+<% if @payment_methods.present? %>
   <table class="table sortable" id='listing_payment_methods' data-hook data-sortable-link="<%= update_positions_admin_payment_methods_url %>">
     <thead>
       <tr data-hook="admin_payment_methods_index_headers">

--- a/backend/app/views/spree/admin/payments/index.html.erb
+++ b/backend/app/views/spree/admin/payments/index.html.erb
@@ -18,13 +18,13 @@
   </div>
 <% end %>
 
-<% if @payments.any? %>
+<% if @payments.present? %>
 
   <div data-hook="payment_list" class="panel panel-default no-border-bottom table-wrapper">
     <%= render partial: 'list', locals: { payments: @payments } %>
   </div>
 
-  <% if @refunds.any? %>
+  <% if @refunds.present? %>
     <fieldset data-hook="payment_list" class="no-border-bottom">
       <legend><%= Spree.t(:refunds) %></legend>
       <%= render partial: 'spree/admin/shared/refunds', locals: { refunds: @refunds, show_actions: true } %>

--- a/backend/app/views/spree/admin/products/index.html.erb
+++ b/backend/app/views/spree/admin/products/index.html.erb
@@ -50,7 +50,7 @@
 
 <%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection } %>
 
-<% if @collection.any? %>
+<% if @collection.present? %>
   <table class="table" id="listing_products">
     <thead>
       <tr data-hook="admin_products_index_headers">

--- a/backend/app/views/spree/admin/promotion_categories/index.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_promotion_category), new_object_url, :icon => 'add', :class => 'btn-success' %>
 <% end %>
 
-<% if @promotion_categories.any? %>
+<% if @promotion_categories.present? %>
   <table class="table">
     <thead>
       <th><%= Spree::PromotionCategory.human_attribute_name :name %></th>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -44,7 +44,7 @@
 
 <%= paginate @promotions %>
 
-<% if @promotions.any? %>
+<% if @promotions.present? %>
   <table class="table">
     <thead>
       <tr>

--- a/backend/app/views/spree/admin/properties/index.html.erb
+++ b/backend/app/views/spree/admin/properties/index.html.erb
@@ -36,7 +36,7 @@
   </div>
 <% end %>
 
-<% if @properties.any? %>
+<% if @properties.present? %>
   <table class="table" id='listing_properties' data-hook>
     <thead>
       <tr data-hook="listing_properties_header">

--- a/backend/app/views/spree/admin/prototypes/index.html.erb
+++ b/backend/app/views/spree/admin/prototypes/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_prototype), new_object_url, { :class => "btn-success", :icon => 'add', 'data-update' => 'new_prototype', :id => 'new_prototype_link'} %>
 <% end %>
 
-<% if @prototypes.any? %>
+<% if @prototypes.present? %>
   <table class="table" id='listing_prototypes' data-hook>
     <thead>
       <tr data-hook="prototypes_header">

--- a/backend/app/views/spree/admin/reimbursement_types/index.html.erb
+++ b/backend/app/views/spree/admin/reimbursement_types/index.html.erb
@@ -2,7 +2,7 @@
   <%= plural_resource_name(Spree::ReimbursementType) %>
 <% end %>
 
-<% if @reimbursement_types.any? %>
+<% if @reimbursement_types.present? %>
   <table class="table" id='listing_reimbursement_types' data-hook>
     <thead>
       <tr data-hook="reimbursement_types_header">

--- a/backend/app/views/spree/admin/return_authorizations/index.html.erb
+++ b/backend/app/views/spree/admin/return_authorizations/index.html.erb
@@ -10,7 +10,7 @@
   / <%= Spree.t(:return_authorizations) %>
 <% end %>
 
-<% if @order.shipments.any?(&:shipped?) && @order.return_authorizations.any? %>
+<% if @order.shipments.any?(&:shipped?) && @order.return_authorizations.present? %>
   <table class="table">
     <thead data-hook="rma_header">
       <tr>

--- a/backend/app/views/spree/admin/roles/index.html.erb
+++ b/backend/app/views/spree/admin/roles/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_role), new_object_url, class: "btn-success", icon: 'add', id: 'admin_new_role_link' %>
 <% end if can? :create, Spree::Role %>
 
-<% if @roles.any? %>
+<% if @roles.present? %>
   <table class="table">
     <thead>
       <tr data-hook="admin_roles_index_headers">

--- a/backend/app/views/spree/admin/shared/named_types/_index.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to new_button_text, new_object_url, { icon: 'add', id: 'admin_new_named_type', :class => "btn-success" } %>
 <% end if can? :create, resource %>
 
-<% if @collection.any? %>
+<% if @collection.present? %>
   <table class="table" id='listing_named_types' data-hook>
     <thead>
       <tr data-hook="named_types_header">

--- a/backend/app/views/spree/admin/shipping_categories/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_shipping_category), new_object_url, :class => "btn-success", :icon => 'add' %>
 <% end if can? :create, Spree::ShippingCategory %>
 
-<% if @shipping_categories.any? %>
+<% if @shipping_categories.present? %>
   <table class="table">
     <thead>
       <tr data-hook="categories_header">

--- a/backend/app/views/spree/admin/shipping_methods/index.html.erb
+++ b/backend/app/views/spree/admin/shipping_methods/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_shipping_method), new_object_url,  :class => "btn-success", :icon => 'add', :id => 'admin_new_shipping_method_link' %>
 <% end if can? :create, Spree::ShippingMethod %>
 
-<% if @shipping_methods.any? %>
+<% if @shipping_methods.present? %>
   <table class="table" id='listing_shipping_methods'>
     <thead>
       <tr data-hook="admin_shipping_methods_index_headers">

--- a/backend/app/views/spree/admin/state_changes/index.html.erb
+++ b/backend/app/views/spree/admin/state_changes/index.html.erb
@@ -4,7 +4,7 @@
   <%= plural_resource_name(Spree::StateChange) %>
 <% end %>
 
-<% if @state_changes.any? %>
+<% if @state_changes.present? %>
   <table class="table" id="listing_order_state_changes" data-hook>
     <thead>
       <tr data-hook="admin_orders_state_changes_headers">

--- a/backend/app/views/spree/admin/stock_locations/index.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_stock_location), new_object_url, { :class => "btn-success", :icon => 'add', :id => 'admin_new_stock_location' } %>
 <% end if can? :create, Spree::StockLocation %>
 
-<% if @stock_locations.any? %>
+<% if @stock_locations.present? %>
   <table class="table" id='listing_stock_locations' data-hook>
     <thead>
       <tr data-hook="stock_locations_header">

--- a/backend/app/views/spree/admin/stock_movements/index.html.erb
+++ b/backend/app/views/spree/admin/stock_movements/index.html.erb
@@ -7,7 +7,7 @@
   <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_resource_list, resource: Spree::StockLocation.model_name.human), admin_stock_locations_path, class: 'btn btn-default' %>
 <% end %>
 
-<% if @stock_movements.any? %>
+<% if @stock_movements.present? %>
 <table class="table" id='listing_stock_movements'>
   <colgroup>
     <col style="width: 35%">

--- a/backend/app/views/spree/admin/stock_transfers/index.html.erb
+++ b/backend/app/views/spree/admin/stock_transfers/index.html.erb
@@ -47,7 +47,7 @@
   </fieldset>
 </div>
 
-<% if @stock_transfers.any? %>
+<% if @stock_transfers.present? %>
   <table class="table" id='listing_stock_transfers' data-hook>
     <thead>
       <tr data-hook='stock_transfers_header'>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_tax_category), new_object_url, class: "btn-success", icon: 'add', id: 'admin_new_tax_categories_link' %>
 <% end if can? :create, Spree::TaxCategory %>
 
-<% if @tax_categories.any? %>
+<% if @tax_categories.present? %>
 <table class="table" id='listing_tax_categories' data-hook>
   <thead>
     <tr data-hook="tax_header">

--- a/backend/app/views/spree/admin/tax_rates/index.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_tax_rate), new_object_url, class: "btn-success", icon: 'add' %>
 <% end if can? :create, Spree::TaxRate %>
 
-<% if @tax_rates.any? %>
+<% if @tax_rates.present? %>
   <table class="table">
     <thead>
       <tr data-hook="rate_header">

--- a/backend/app/views/spree/admin/taxonomies/index.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_taxonomy), new_object_url, class: "btn-success", icon: 'add', id: 'admin_new_taxonomy_link' %>
 <% end %>
 
-<% if @taxonomies.any? %>
+<% if @taxonomies.present? %>
   <div id="list-taxonomies" data-hook>
     <%= render 'list' %>
   </div>

--- a/backend/app/views/spree/admin/trackers/index.html.erb
+++ b/backend/app/views/spree/admin/trackers/index.html.erb
@@ -6,7 +6,7 @@
   <%= button_link_to Spree.t(:new_tracker), new_object_url, :class => "btn-success", :icon => 'add', :id => 'admin_new_tracker_link' %>
 <% end if can? :create, Spree::Tracker %>
 
-<% if @trackers.any? %>
+<% if @trackers.present? %>
   <table class="table">
     <colgroup>
       <col style="width: 30%">

--- a/backend/app/views/spree/admin/variants/index.html.erb
+++ b/backend/app/views/spree/admin/variants/index.html.erb
@@ -3,7 +3,7 @@
 <%# Place for new variant form %>
 <div id="new_variant" data-hook></div>
 
-<% if @variants.any? %>
+<% if @variants.present? %>
   <table class="table sortable" data-sortable-link="<%= update_positions_admin_product_variants_path(@product) %>">
     <thead data-hook="variants_header">
       <tr>

--- a/backend/app/views/spree/admin/zones/index.html.erb
+++ b/backend/app/views/spree/admin/zones/index.html.erb
@@ -8,7 +8,7 @@
 
 <%= paginate @zones %>
 
-<% if @zones.any? %>
+<% if @zones.present? %>
   <table class="table" id='listing_zones' data-hook>
     <thead>
       <tr data-hook="zones_header">


### PR DESCRIPTION
Use `present?` instead of `any?` to save one count query if there are more than zero records and ActiveRecord::Relation object is not loaded
Earlier two queries were fired -> one count query and one data load query(if count query results greater than 0)
Now only one data load query is fired.
