### PR TITLE
save subsequent cached queries by saving the result in instance variable

### DIFF
--- a/core/app/models/concerns/spree/user_methods.rb
+++ b/core/app/models/concerns/spree/user_methods.rb
@@ -25,7 +25,8 @@ module Spree
 
     # has_spree_role? simply needs to return true or false whether a user has a role or not.
     def has_spree_role?(role_in_question)
-      spree_roles.where(name: role_in_question.to_s).any?
+      instance_variable_get("@#{role_in_question}") ||
+        instance_variable_set("@#{role_in_question}", spree_roles.where(name: role_in_question.to_s).any?)
     end
 
     def last_incomplete_spree_order


### PR DESCRIPTION
By using instance_variable_set and instance_variable_get methods, all the subsequent cached queries for user roles are removed.
