### PR TITLE
Reduce queries on store product show page

### DIFF
--- a/frontend/app/controllers/spree/products_controller.rb
+++ b/frontend/app/controllers/spree/products_controller.rb
@@ -40,7 +40,7 @@ module Spree
         else
           @products = Product.active(current_currency)
         end
-        @product = @products.includes(:variants_including_master).friendly.find(params[:id])
+        @product = @products.includes(:variants_including_master, variant_images: :viewable).friendly.find(params[:id])
       end
 
       def load_taxon

--- a/frontend/app/views/spree/products/_cart_form.html.erb
+++ b/frontend/app/views/spree/products/_cart_form.html.erb
@@ -1,13 +1,13 @@
 <%= form_for :order, url: populate_orders_path do |f| %>
   <div class="row" id="inside-product-cart-form" data-hook="inside_product_cart_form" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
-    <% if @product.variants_and_option_values(current_currency).any? %>
+    <% if @product.variants_and_option_values(current_currency).present? %>
       <div id="product-variants" class="col-md-6">
         <h3 class="product-section-title"><%= Spree.t(:variants) %></h3>
         <ul class="list-group">
           <% @product.variants_and_option_values(current_currency).each_with_index do |variant, index| %>
             <li>
               <%= radio_button_tag "variant_id", variant.id, index == 0,
-                  'data-price' => variant.price_in(current_currency).money, 
+                  'data-price' => variant.price_in(current_currency).money,
                   'data-in-stock' => variant.can_supply?
               %>
               <%= label_tag "variant_id_#{ variant.id }" do %>
@@ -42,7 +42,7 @@
 
           <% if @product.master.can_supply? %>
             <link itemprop="availability" href="https://schema.org/InStock" />
-          <% elsif @product.variants.empty? %>
+          <% elsif @product.variants.present? %>
             <br />
             <span class="out-of-stock"><%= Spree.t(:out_of_stock) %></span>
           <% end %>

--- a/frontend/app/views/spree/products/_promotions.html.erb
+++ b/frontend/app/views/spree/products/_promotions.html.erb
@@ -1,6 +1,6 @@
 <% promotions = @product.possible_promotions %>
 
-<% if promotions.any? %>
+<% if promotions.present? %>
   <div id="promotions">
     <h3><%= Spree.t(:promotions) %></h3>
     <% promotions.each do |promotion| %>

--- a/frontend/app/views/spree/products/_properties.html.erb
+++ b/frontend/app/views/spree/products/_properties.html.erb
@@ -1,4 +1,4 @@
-<% unless @product_properties.empty? %>  
+<% if @product_properties.present? %>
   <h3 class="product-section-title"><%= Spree.t('properties')%></h3>
   <table id="product-properties" class="table table-striped" data-hook>
     <tbody>

--- a/frontend/app/views/spree/products/index.html.erb
+++ b/frontend/app/views/spree/products/index.html.erb
@@ -1,4 +1,4 @@
-<% if "spree/products" == params[:controller] && @taxon || !@taxonomies.empty? %>
+<% if "spree/products" == params[:controller] && @taxon || @taxonomies.present? %>
   <% content_for :sidebar do %>
     <div data-hook="homepage_sidebar_navigation">
       <% if "spree/products" == params[:controller] && @taxon %>
@@ -12,7 +12,7 @@
 
 <% if params[:keywords] %>
   <div data-hook="search_results">
-    <% if @products.empty? %>
+    <% if !@products.present? %>
       <h6 class="search-results-title"><%= Spree.t(:no_products_found) %></h6>
     <% else %>
       <%= render :partial => 'spree/shared/products', :locals => { :products => @products, :taxon => @taxon } %>


### PR DESCRIPTION
N + 1 queries are reduced for variants and also count query is saved if there are records present.
Earlier two queries were fired one count and one data load(if count query result greater than 0)
Now only data load query is fired.
