### PR TITLE
Fix errors bug on admin payment method form

### DIFF
--- a/backend/app/views/spree/admin/payment_methods/_form.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/_form.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_payment_method_form_fields">
 
-  <div data-hook="payment_method" class="row">
+  <div class="row">
 
     <div class="col-md-4">
       <div id="preference-settings" data-hook class="form-group">
@@ -42,9 +42,12 @@
     </div>
 
     <div class="col-md-8">
-      <div data-hook="name" class="form-group">
-        <%= label_tag :payment_method_name, Spree.t(:name) %>
-        <%= text_field :payment_method, :name, :class => 'form-control' %>
+      <div data-hook="admin_payment_method_form_name_field" class="form-group">
+        <%= field_container :payment_method, :name, class: ['form-group'] do %>
+          <%= label_tag :payment_method_name, Spree.t(:name) %>
+          <%= text_field :payment_method, :name, :class => 'form-control' %>
+          <%= error_message_on :payment_method, :name %>
+        <% end %>
       </div>
       <div data-hook="description" class="form-group">
         <%= label_tag :payment_method_description, Spree.t(:description) %>

--- a/backend/app/views/spree/admin/payment_methods/edit.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/edit.html.erb
@@ -7,8 +7,8 @@
 <%= form_for @payment_method, :url => admin_payment_method_path(@payment_method) do |f| %>
   <fieldset>
     <%= render :partial => 'form', :locals => { :f => f } %>
-    <div data-hook="buttons" class="actions">
-      <%= button Spree.t('actions.update'), 'save' %>
+    <div data-hook="admin_shipping_method_edit_form_buttons">
+      <%= render partial: 'spree/admin/shared/edit_resource_links' %>
     </div>
   </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/payment_methods/new.html.erb
+++ b/backend/app/views/spree/admin/payment_methods/new.html.erb
@@ -7,8 +7,8 @@
 <%= form_for @payment_method, :url => collection_url do |f| %>
   <fieldset>
     <%= render :partial => 'form', :locals => { :f => f } %>
-    <div data-hook="buttons" class="actions">
-      <%= button Spree.t(:create), 'save' %>
-    </div>
+      <div data-hook="admin_shipping_method_new_form_buttons">
+        <%= render partial: 'spree/admin/shared/new_resource_links' %>
+      </div>
   </fieldset>
 <% end %>

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -4,7 +4,7 @@ module Spree
 
     delegate :authorize, :purchase, :capture, :void, :credit, to: :provider
 
-    validates :name, :type, presence: true
+    validates :type, presence: true
 
     preference :server, :string, default: 'test'
     preference :test_mode, :boolean, default: true


### PR DESCRIPTION
Name validation is in PaymentMethod class so not required in any of its inherited classes otherwise there will be double validation fail error.
