### PR TITLE
Refactor associate user method in order model

### DIFF
--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -273,7 +273,7 @@ module Spree
 
       # immediately persist the changes we just made, but don't use save
       # since we might have an invalid address associated
-      update_columns(changes)
+      update_columns(changes) if persisted?
     end
 
     def quantity_of(variant, options = {})

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -273,7 +273,7 @@ module Spree
 
       # immediately persist the changes we just made, but don't use save
       # since we might have an invalid address associated
-      self.class.unscoped.where(id: self).update_all(changes)
+      update_columns(changes)
     end
 
     def quantity_of(variant, options = {})


### PR DESCRIPTION
`if persisted?` is used so that if a new record is there it will not throw error and will not save order object also and query will also be not fired in that case which was fired earlier 
Also all specs are succesfull by this change
