### PR TITLE
Fix errors on admin end forms

### DIFF
--- a/api/app/views/spree/api/v1/images/new.v1.rabl
+++ b/api/app/views/spree/api/v1/images/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*image_attributes] }
+node(:required_attributes) { required_fields_for(Spree::Image) }

--- a/api/app/views/spree/api/v1/option_types/new.v1.rabl
+++ b/api/app/views/spree/api/v1/option_types/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*option_type_attributes] }
+node(:required_attributes) { required_fields_for(Spree::OptionType) }

--- a/api/app/views/spree/api/v1/option_values/new.v1.rabl
+++ b/api/app/views/spree/api/v1/option_values/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*option_value_attributes] }
+node(:required_attributes) { required_fields_for(Spree::OptionValue) }

--- a/api/spec/controllers/spree/api/v1/images_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/images_controller_spec.rb
@@ -16,6 +16,12 @@ module Spree
     context "as an admin" do
       sign_in_as_admin!
 
+      it "can learn how to create a new image" do
+        api_get :new, product_id: product.id
+        expect(json_response["attributes"]).to eq(attributes.map(&:to_s))
+        expect(json_response["required_attributes"]).to be_empty
+      end
+
       it "can upload a new image for a variant" do
         expect do
           api_post :create,

--- a/api/spec/controllers/spree/api/v1/option_types_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/option_types_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Api::V1::OptionTypesController, :type => :controller do
     render_views
 
-    let(:attributes) { [:id, :name, :position, :presentation] }
+    let(:attributes) { [:id, :name, :presentation, :position] }
     let!(:option_value) { create(:option_value) }
     let!(:option_type) { option_value.option_type }
 
@@ -15,7 +15,7 @@ module Spree
     def check_option_values(option_values)
       expect(option_values.count).to eq(1)
       expect(option_values.first).to have_attributes([:id, :name, :presentation,
-                                                  :option_type_name, :option_type_id])
+                                                      :option_type_id, :option_type_name])
     end
 
     it "can list all option types" do
@@ -46,6 +46,12 @@ module Spree
       api_get :show, :id => option_type.id
       expect(json_response).to have_attributes(attributes)
       check_option_values(json_response["option_values"])
+    end
+
+    it "can learn how to create a new option type" do
+      api_get :new
+      expect(json_response["attributes"]).to eq(attributes.map(&:to_s))
+      expect(json_response["required_attributes"]).to_not be_empty
     end
 
     it "cannot create a new option type" do

--- a/api/spec/controllers/spree/api/v1/option_values_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/option_values_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Api::V1::OptionValuesController, :type => :controller do
     render_views
 
-    let(:attributes) { [:id, :name, :presentation, :option_type_name, :option_type_name] }
+    let(:attributes) { [:id, :name, :presentation, :option_type_name, :option_type_id, :option_type_presentation] }
     let!(:option_value) { create(:option_value) }
     let!(:option_type) { option_value.option_type }
 
@@ -85,6 +85,12 @@ module Spree
 
       context "as an admin" do
         sign_in_as_admin!
+
+        it "can learn how to create a new option value" do
+          api_get :new
+          expect(json_response["attributes"]).to eq(attributes.map(&:to_s))
+          expect(json_response["required_attributes"]).to_not be_empty
+        end
 
         it "can create an option value" do
           api_post :create, :option_value => {

--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -50,24 +50,24 @@
 //= require spree/backend/variant_management
 //= require spree/backend/zone
 
-Spree.routes.clear_cache = Spree.pathFor('admin/general_settings/clear_cache')
+Spree.routes.clear_cache = Spree.adminPathFor('general_settings/clear_cache')
 Spree.routes.checkouts_api = Spree.pathFor('api/v1/checkouts')
 Spree.routes.classifications_api = Spree.pathFor('api/v1/classifications')
 Spree.routes.option_type_search = Spree.pathFor('api/v1/option_types')
 Spree.routes.option_value_search = Spree.pathFor('api/v1/option_values')
 Spree.routes.orders_api = Spree.pathFor('api/v1/orders')
 Spree.routes.products_api = Spree.pathFor('api/v1/products')
-Spree.routes.product_search = Spree.pathFor('admin/search/products')
+Spree.routes.product_search = Spree.adminPathFor('search/products')
 Spree.routes.shipments_api = Spree.pathFor('api/v1/shipments')
 Spree.routes.checkouts_api = Spree.pathFor('api/v1/checkouts')
 Spree.routes.stock_locations_api = Spree.pathFor('api/v1/stock_locations')
 Spree.routes.taxon_products_api = Spree.pathFor('api/v1/taxons/products')
 Spree.routes.taxons_search = Spree.pathFor('api/v1/taxons')
-Spree.routes.user_search = Spree.pathFor('admin/search/users')
+Spree.routes.user_search = Spree.adminPathFor('search/users')
 Spree.routes.variants_api = Spree.pathFor('api/v1/variants')
 
 Spree.routes.edit_product = function(product_id) {
-  return Spree.pathFor('admin/products/' + product_id + '/edit')
+  return Spree.adminPathFor('products/' + product_id + '/edit')
 }
 
 Spree.routes.payments_api = function(order_id) {

--- a/backend/app/views/spree/admin/countries/_form.html.erb
+++ b/backend/app/views/spree/admin/countries/_form.html.erb
@@ -1,12 +1,18 @@
 <div data-hook="admin_country_form_fields">
   <div data-hook="name" class="form-group">
-    <%= f.label :name, Spree.t(:name) %>
-    <%= f.text_field :name, :class => 'form-control' %>
+    <%= f.field_container :name, class: ["form-group"] do %>
+      <%= f.label :name, Spree.t(:name) %>
+      <%= f.text_field :name, :class => 'form-control' %>
+      <%= error_message_on :country, :name %>
+    <% end %>
   </div>
 
   <div data-hook="iso_name" class="form-group">
-    <%= f.label :iso_name, Spree.t(:iso_name) %>
-    <%= f.text_field :iso_name, :class => 'form-control' %>
+    <%= f.field_container :iso_name, class: ["form-group"] do %>
+      <%= f.label :iso_name, Spree.t(:iso_name) %>
+      <%= f.text_field :iso_name, :class => 'form-control' %>
+      <%= error_message_on :country, :iso_name %>
+    <% end %>
   </div>
 
   <div data-hook="states_required" class="checkbox">

--- a/backend/app/views/spree/admin/countries/new.html.erb
+++ b/backend/app/views/spree/admin/countries/new.html.erb
@@ -6,7 +6,7 @@
   <%= back_to_list_button(Spree::Country.model_name.human, admin_countries_path) %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @countries } %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @country } %>
 
 <%= form_for [:admin, @country] do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/promotion_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/promotion_categories/_form.html.erb
@@ -1,8 +1,9 @@
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @promotion } %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @promotion_category } %>
 
 <%= f.field_container :name, class: ['form-group'] do %>
   <%= f.label :name %>
   <%= f.text_field :name, :class => 'form-control' %>
+  <%= error_message_on :promotion_category, :name %>
 <% end %>
 <%= f.field_container :code, class: ['form-group'] do %>
   <%= f.label :code %>

--- a/backend/app/views/spree/admin/promotions/_form.html.erb
+++ b/backend/app/views/spree/admin/promotions/_form.html.erb
@@ -5,6 +5,7 @@
     <%= f.field_container :name, class: ['form-group'] do %>
       <%= f.label :name %>
       <%= f.text_field :name, :class => 'form-control' %>
+      <%= error_message_on :promotion, :name %>
     <% end %>
 
     <%= f.field_container :code, class: ['form-group'] do %>

--- a/backend/app/views/spree/admin/roles/_form.html.erb
+++ b/backend/app/views/spree/admin/roles/_form.html.erb
@@ -1,7 +1,10 @@
 <div data-hook="admin_role_form_fields">
   <div data-hook="role_name" class="form-group">
-    <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.field_container :name, class: ["form-group"] do %>
+      <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
+      <%= f.text_field :name, class: 'form-control' %>
+      <%= error_message_on :role, :name %>
+    <% end %>
   </div>
 
   <div data-hook="additional_role_fields"></div>

--- a/backend/app/views/spree/admin/roles/edit.html.erb
+++ b/backend/app/views/spree/admin/roles/edit.html.erb
@@ -6,6 +6,8 @@
   <%= back_to_list_button(Spree::Role.model_name.human, admin_roles_path) %>
 <% end %>
 
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @role } %>
+
 <%= form_for [:admin, @role] do |f| %>
   <fieldset>
     <%= render partial: 'form', locals: { f: f } %>

--- a/backend/app/views/spree/admin/roles/new.html.erb
+++ b/backend/app/views/spree/admin/roles/new.html.erb
@@ -6,6 +6,8 @@
   <%= back_to_list_button(Spree::Role.model_name.human, admin_roles_path) %>
 <% end %>
 
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @role } %>
+
 <%= form_for [:admin, @role] do |f| %>
   <fieldset>
     <%= render partial: 'form', locals: { f: f } %>

--- a/backend/app/views/spree/admin/shared/named_types/_form.html.erb
+++ b/backend/app/views/spree/admin/shared/named_types/_form.html.erb
@@ -2,6 +2,7 @@
   <%= f.field_container :name, class: ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
     <%= f.text_field :name, class: 'form-control' %>
+    <%= error_message_on :object, :name %>
   <% end %>
   <div class="checkbox">
     <%= label_tag :active do %>

--- a/backend/app/views/spree/admin/shipping_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/shipping_categories/_form.html.erb
@@ -1,6 +1,9 @@
 <div data-hook="admin_shipping_category_form_fields">
   <div data-hook="name" class="form-group">
-    <%= label_tag :shipping_category_name, Spree.t(:name) %><br>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.field_container :name, class: ["form-group"] do %>
+      <%= f.label :name, Spree.t(:name) %><br>
+      <%= f.text_field :name, class: 'form-control' %>
+      <%= error_message_on :shipping_category, :name %>
+    <% end %>
   </div>
 </div>

--- a/backend/app/views/spree/admin/states/_form.html.erb
+++ b/backend/app/views/spree/admin/states/_form.html.erb
@@ -3,6 +3,7 @@
     <%= f.field_container :name, class: ['form-group'] do %>
       <%= f.label :name, Spree.t(:name) %>
       <%= f.text_field :name, :class => 'form-control' %>
+      <%= error_message_on :state, :name %>
     <% end %>
   </div>
   <div class="col-md-6">

--- a/backend/app/views/spree/admin/stock_locations/_form.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/_form.html.erb
@@ -3,8 +3,9 @@
     <div class="col-md-9" data-hook="stock_location_names">
       <div data-hook="stock_location_name">
         <%= f.field_container :name, class: ['form-group']  do %>
-        <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
-        <%= f.text_field :name, class: 'form-control', required: true %>
+          <%= f.label :name, Spree.t(:name) %> <span class="required">*</span><br />
+          <%= f.text_field :name, class: 'form-control', required: true %>
+          <%= error_message_on :stock_location, :name %>
         <% end %>
       </div>
       <div data-hook="stock_location_admin_name">

--- a/backend/app/views/spree/admin/stock_locations/new.html.erb
+++ b/backend/app/views/spree/admin/stock_locations/new.html.erb
@@ -6,7 +6,7 @@
   <%= link_to_with_icon 'arrow-left', Spree.t(:back_to_stock_locations_list), admin_stock_locations_path, :class => 'btn btn-primary' %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_locations } %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @stock_location } %>
 
 <%= form_for [:admin, @stock_location] do |f| %>
   <fieldset>

--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -2,6 +2,7 @@
   <%= f.field_container :name, :class => ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %>
     <%= f.text_field :name, :class => 'form-control' %>
+    <%= error_message_on :tax_category, :name %>
   <% end %>
 
   <%= f.field_container :tax_code, :class => ['form-group'] do %>

--- a/backend/app/views/spree/admin/tax_rates/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_rates/_form.html.erb
@@ -13,10 +13,13 @@
           <%= f.text_field :name, :class => 'form-control' %>
         </div>
         <div data-hook="rate" class="form-group">
-          <%= f.label :amount, Spree.t(:rate) %>
-          <%= f.text_field :amount, :class => 'form-control' %>
+          <%= f.field_container :amount, class: ["form-group"] do %>
+            <%= f.label :amount, Spree.t(:rate) %>
+            <%= f.text_field :amount, :class => 'form-control' %>
+            <%= error_message_on :tax_rate, :amount %>
+          <% end %>
           <p class="help-block">
-            <%= Spree.t(:tax_rate_amount_explanation) %>
+          <%= Spree.t(:tax_rate_amount_explanation) %>
           </p>
         </div>
         <div data-hook="included" class="form-group">

--- a/backend/app/views/spree/admin/taxonomies/_form.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_inside_taxonomy_form" class="form-group">
   <%= f.field_container :name, class: ['form-group'] do %>
     <%= f.label :name, Spree.t(:name) %> <span class="required">*</span>
+    <%= f.text_field :name, :class => 'form-control' %>
     <%= error_message_on :taxonomy, :name, :class => 'error-message' %>
-    <%= text_field :taxonomy, :name, :class => 'form-control' %>
   <% end %>
 </div>

--- a/backend/app/views/spree/admin/taxonomies/new.html.erb
+++ b/backend/app/views/spree/admin/taxonomies/new.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title do %>
   <%= Spree.t(:new_taxonomy) %>
 <% end %>
+<%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @taxonomy } %>
 
 <% content_for :page_actions do %>
   <%= back_to_list_button(Spree::Taxonomy.model_name.human, admin_taxonomies_path) %>

--- a/backend/app/views/spree/admin/trackers/_form.html.erb
+++ b/backend/app/views/spree/admin/trackers/_form.html.erb
@@ -1,8 +1,11 @@
 <div data-hook="admin_tracker_form_fields" class="row">
   <div class="col-md-4">
     <div data-hook="analytics_id" class="form-group">
-      <%= label_tag nil, Spree.t(:google_analytics_id) %>
-      <%= text_field :tracker, :analytics_id, :class => 'form-control' %>
+      <%= f.field_container :analytics_id, class: ["form-group"] do %>
+        <%= f.label :analytics_id, Spree.t(:google_analytics_id) %>
+        <%= f.text_field :analytics_id, :class => 'form-control' %>
+        <%= error_message_on :tracker, :analytics_id %>
+      <% end %>
     </div>
   </div>
   <div class="col-md-4">
@@ -18,11 +21,11 @@
         <%= label_tag :tracker_active_false do %>
           <%= radio_button(:tracker, :active, false) %>
           <%= Spree.t(:say_no) %>
-        <% end %>        
+        <% end %>
       </div>
     </div>
   </div>
-  
+
   <div data-hook="additional_tracker_fields"></div>
 
 </div>

--- a/backend/app/views/spree/admin/trackers/edit.html.erb
+++ b/backend/app/views/spree/admin/trackers/edit.html.erb
@@ -5,6 +5,8 @@
 <%= render :partial => 'spree/admin/shared/error_messages', :locals => { :target => @tracker } %>
 
 <%= form_for [:admin, @tracker] do |f| %>
-  <%= render :partial => 'form', :locals => { :f => f } %>
-  <%= render :partial => 'spree/admin/shared/edit_resource_links' %>  
+  <fieldset>
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+  </fieldset>
 <% end %>

--- a/backend/app/views/spree/admin/zones/_form.html.erb
+++ b/backend/app/views/spree/admin/zones/_form.html.erb
@@ -9,6 +9,7 @@
         <%= zone_form.field_container :name, class: ['form-group'] do %>
           <%= zone_form.label :name, Spree.t(:name) %>
           <%= zone_form.text_field :name, :class => 'form-control' %>
+          <%= error_message_on :zone, :name %>
         <% end %>
 
         <%= zone_form.field_container :description, class: ['form-group'] do %>

--- a/core/app/assets/javascripts/spree.js.coffee.erb
+++ b/core/app/assets/javascripts/spree.js.coffee.erb
@@ -10,9 +10,15 @@ class window.Spree
   @mountedAt: ->
     "<%= Rails.application.routes.url_helpers.spree_path(trailing_slash: true) %>"
 
+  @adminPath: ->
+    '<%= Spree.admin_path.gsub(/\A(\/)?(.*[^\/])(\/)?\z/, '\\2/') %>'
+
   @pathFor: (path) ->
     locationOrigin = "#{window.location.protocol}//#{window.location.hostname}" + (if window.location.port then ":#{window.location.port}" else "")
     @url("#{locationOrigin}#{@mountedAt()}#{path}", @url_params).toString()
+
+  @adminPathFor: (path) ->
+    @pathFor("#{@adminPath()}#{path}")
 
   # Helper function to take a URL and add query parameters to it
   # Uses the JSUri library from here: https://github.com/derek-watson/jsUri

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -31,6 +31,13 @@ module Spree
     Spree::Config[:admin_path]
   end
 
+  # Used to configure admin_path for Spree
+  #
+  # Example:
+  #
+  # write the following line in `config/initializers/spree.rb`
+  #   Spree.admin_path = '/custom-path'
+
   def self.admin_path=(path)
     Spree::Config[:admin_path] = path
   end


### PR DESCRIPTION
In backend forms, errors are displayed in inline format with field in red colour and also field and label are marked with red colour. 
