### PR TITLE
reduce N+1 queries for inventory units update

### DIFF
--- a/api/app/models/spree/option_value_decorator.rb
+++ b/api/app/models/spree/option_value_decorator.rb
@@ -1,9 +1,0 @@
-Spree::OptionValue.class_eval do
-  def option_type_name
-    option_type.name
-  end
-
-  def option_type_presentation
-    option_type.presentation
-  end
-end

--- a/api/app/views/spree/api/v1/images/new.v1.rabl
+++ b/api/app/views/spree/api/v1/images/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*image_attributes] }
+node(:required_attributes) { required_fields_for(Spree::Image) }

--- a/api/app/views/spree/api/v1/option_types/new.v1.rabl
+++ b/api/app/views/spree/api/v1/option_types/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*option_type_attributes] }
+node(:required_attributes) { required_fields_for(Spree::OptionType) }

--- a/api/app/views/spree/api/v1/option_values/new.v1.rabl
+++ b/api/app/views/spree/api/v1/option_values/new.v1.rabl
@@ -1,0 +1,3 @@
+object false
+node(:attributes) { [*option_value_attributes] }
+node(:required_attributes) { required_fields_for(Spree::OptionValue) }

--- a/api/spec/controllers/spree/api/v1/images_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/images_controller_spec.rb
@@ -16,6 +16,12 @@ module Spree
     context "as an admin" do
       sign_in_as_admin!
 
+      it "can learn how to create a new image" do
+        api_get :new, product_id: product.id
+        expect(json_response["attributes"]).to eq(attributes.map(&:to_s))
+        expect(json_response["required_attributes"]).to be_empty
+      end
+
       it "can upload a new image for a variant" do
         expect do
           api_post :create,

--- a/api/spec/controllers/spree/api/v1/option_types_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/option_types_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Api::V1::OptionTypesController, :type => :controller do
     render_views
 
-    let(:attributes) { [:id, :name, :position, :presentation] }
+    let(:attributes) { [:id, :name, :presentation, :position] }
     let!(:option_value) { create(:option_value) }
     let!(:option_type) { option_value.option_type }
 
@@ -15,7 +15,7 @@ module Spree
     def check_option_values(option_values)
       expect(option_values.count).to eq(1)
       expect(option_values.first).to have_attributes([:id, :name, :presentation,
-                                                  :option_type_name, :option_type_id])
+                                                      :option_type_id, :option_type_name])
     end
 
     it "can list all option types" do
@@ -46,6 +46,12 @@ module Spree
       api_get :show, :id => option_type.id
       expect(json_response).to have_attributes(attributes)
       check_option_values(json_response["option_values"])
+    end
+
+    it "can learn how to create a new option type" do
+      api_get :new
+      expect(json_response["attributes"]).to eq(attributes.map(&:to_s))
+      expect(json_response["required_attributes"]).to_not be_empty
     end
 
     it "cannot create a new option type" do

--- a/api/spec/controllers/spree/api/v1/option_values_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/option_values_controller_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe Api::V1::OptionValuesController, :type => :controller do
     render_views
 
-    let(:attributes) { [:id, :name, :presentation, :option_type_name, :option_type_name] }
+    let(:attributes) { [:id, :name, :presentation, :option_type_name, :option_type_id, :option_type_presentation] }
     let!(:option_value) { create(:option_value) }
     let!(:option_type) { option_value.option_type }
 
@@ -85,6 +85,12 @@ module Spree
 
       context "as an admin" do
         sign_in_as_admin!
+
+        it "can learn how to create a new option value" do
+          api_get :new
+          expect(json_response["attributes"]).to eq(attributes.map(&:to_s))
+          expect(json_response["required_attributes"]).to_not be_empty
+        end
 
         it "can create an option value" do
           api_post :create, :option_value => {

--- a/backend/app/assets/javascripts/spree/backend.js
+++ b/backend/app/assets/javascripts/spree/backend.js
@@ -50,24 +50,24 @@
 //= require spree/backend/variant_management
 //= require spree/backend/zone
 
-Spree.routes.clear_cache = Spree.pathFor('admin/general_settings/clear_cache')
+Spree.routes.clear_cache = Spree.adminPathFor('general_settings/clear_cache')
 Spree.routes.checkouts_api = Spree.pathFor('api/v1/checkouts')
 Spree.routes.classifications_api = Spree.pathFor('api/v1/classifications')
 Spree.routes.option_type_search = Spree.pathFor('api/v1/option_types')
 Spree.routes.option_value_search = Spree.pathFor('api/v1/option_values')
 Spree.routes.orders_api = Spree.pathFor('api/v1/orders')
 Spree.routes.products_api = Spree.pathFor('api/v1/products')
-Spree.routes.product_search = Spree.pathFor('admin/search/products')
+Spree.routes.product_search = Spree.adminPathFor('search/products')
 Spree.routes.shipments_api = Spree.pathFor('api/v1/shipments')
 Spree.routes.checkouts_api = Spree.pathFor('api/v1/checkouts')
 Spree.routes.stock_locations_api = Spree.pathFor('api/v1/stock_locations')
 Spree.routes.taxon_products_api = Spree.pathFor('api/v1/taxons/products')
 Spree.routes.taxons_search = Spree.pathFor('api/v1/taxons')
-Spree.routes.user_search = Spree.pathFor('admin/search/users')
+Spree.routes.user_search = Spree.adminPathFor('search/users')
 Spree.routes.variants_api = Spree.pathFor('api/v1/variants')
 
 Spree.routes.edit_product = function(product_id) {
-  return Spree.pathFor('admin/products/' + product_id + '/edit')
+  return Spree.adminPathFor('products/' + product_id + '/edit')
 }
 
 Spree.routes.payments_api = function(order_id) {

--- a/core/app/assets/javascripts/spree.js.coffee.erb
+++ b/core/app/assets/javascripts/spree.js.coffee.erb
@@ -10,9 +10,15 @@ class window.Spree
   @mountedAt: ->
     "<%= Rails.application.routes.url_helpers.spree_path(trailing_slash: true) %>"
 
+  @adminPath: ->
+    '<%= Spree.admin_path.gsub(/\A(\/)?(.*[^\/])(\/)?\z/, '\\2/') %>'
+
   @pathFor: (path) ->
     locationOrigin = "#{window.location.protocol}//#{window.location.hostname}" + (if window.location.port then ":#{window.location.port}" else "")
     @url("#{locationOrigin}#{@mountedAt()}#{path}", @url_params).toString()
+
+  @adminPathFor: (path) ->
+    @pathFor("#{@adminPath()}#{path}")
 
   # Helper function to take a URL and add query parameters to it
   # Uses the JSUri library from here: https://github.com/derek-watson/jsUri

--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -4,7 +4,7 @@ module Spree
 
     delegate :authorize, :purchase, :capture, :void, :credit, to: :provider
 
-    validates :name, :type, presence: true
+    validates :type, presence: true
 
     preference :server, :string, default: 'test'
     preference :test_mode, :boolean, default: true

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -52,13 +52,8 @@ module Spree
       end
     end
 
-    def self.finalize_units!(inventory_units)
-      inventory_units.map do |iu|
-        iu.update_columns(
-          pending: false,
-          updated_at: Time.current,
-        )
-      end
+    def self.finalize_units!
+      update_all(pending: false, updated_at: Time.current)
     end
 
     def find_stock_item

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -15,6 +15,14 @@ module Spree
 
     self.whitelisted_ransackable_attributes = ['presentation']
 
+    def option_type_name
+      option_type.name
+    end
+
+    def option_type_presentation
+      option_type.presentation
+    end
+
     private
 
     def touch_all_variants

--- a/core/app/models/spree/price.rb
+++ b/core/app/models/spree/price.rb
@@ -24,13 +24,11 @@ module Spree
       Spree::Money.new(amount || 0, { currency: currency })
     end
 
-    def price
-      amount
+    def amount=(amount)
+      self[:amount] = Spree::LocalizedNumber.parse(amount)
     end
 
-    def price=(price)
-      self[:amount] = Spree::LocalizedNumber.parse(price)
-    end
+    alias_attribute :price, :amount
 
     def price_including_vat_for(price_options)
       options = price_options.merge(tax_category: variant.tax_category)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -137,7 +137,7 @@ module Spree
     end
 
     def finalize!
-      InventoryUnit.finalize_units!(inventory_units)
+      inventory_units.finalize_units!
       after_resume
     end
 

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -31,6 +31,13 @@ module Spree
     Spree::Config[:admin_path]
   end
 
+  # Used to configure admin_path for Spree
+  #
+  # Example:
+  #
+  # write the following line in `config/initializers/spree.rb`
+  #   Spree.admin_path = '/custom-path'
+
   def self.admin_path=(path)
     Spree::Config[:admin_path] = path
   end

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -105,14 +105,18 @@ describe Spree::InventoryUnit, :type => :model do
   context "#finalize_units!" do
     let!(:stock_location) { create(:stock_location) }
     let(:variant) { create(:variant) }
+    let (:shipment) { create(:shipment) }
     let(:inventory_units) { [
       create(:inventory_unit, variant: variant),
       create(:inventory_unit, variant: variant)
     ] }
+    before do
+      shipment.inventory_units = inventory_units
+    end
 
     it "should create a stock movement" do
-      Spree::InventoryUnit.finalize_units!(inventory_units)
-      expect(inventory_units.any?(&:pending)).to be false
+      expect { shipment.inventory_units.finalize_units! }.
+        to change { shipment.inventory_units.where(pending: false).count }.by 2
     end
   end
 

--- a/core/spec/models/spree/price_spec.rb
+++ b/core/spec/models/spree/price_spec.rb
@@ -1,6 +1,34 @@
 require 'spec_helper'
 
 describe Spree::Price, :type => :model do
+  describe '#amount=' do
+    let(:price) { Spree::Price.new }
+    let(:amount) { '3,0A0' }
+
+    before do
+      price.amount = amount
+    end
+
+    it 'is expected to equal to localized number' do
+      expect(price.amount).to eq(Spree::LocalizedNumber.parse(amount))
+    end
+  end
+
+  describe '#price' do
+    let(:price) { Spree::Price.new }
+    let(:amount) { 3000.00 }
+
+    context 'when amount is changed' do
+      before do
+        price.amount = amount
+      end
+
+      it 'is expected to equal to price' do
+        expect(price.amount).to eq(price.price)
+      end
+    end
+  end
+
   describe 'validations' do
     let(:variant) { stub_model Spree::Variant }
     subject { Spree::Price.new variant: variant, amount: amount }


### PR DESCRIPTION
Inventory units are updated for every shipment singularily using update_columns
Using update_all instead to save n+1 queries.
