### PR TITLE
payment method double error fix

### DIFF
--- a/core/app/models/spree/gateway.rb
+++ b/core/app/models/spree/gateway.rb
@@ -4,7 +4,7 @@ module Spree
 
     delegate :authorize, :purchase, :capture, :void, :credit, to: :provider
 
-    validates :name, :type, presence: true
+    validates :type, presence: true
 
     preference :server, :string, default: 'test'
     preference :test_mode, :boolean, default: true


### PR DESCRIPTION
Removing name presence validation from Gateway class because its already present in its superclass PaymentMethod.

It fixes the double validation error on gateway objects.
