### PR TITLE
Modify javascript_exists?, stylesheet_exists? and file_exists? in install_generator.rb

### DIFF
--- a/core/lib/generators/spree/install/install_generator.rb
+++ b/core/lib/generators/spree/install/install_generator.rb
@@ -191,18 +191,18 @@ Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
     protected
 
     def javascript_exists?(script)
-      extensions = %w(.coffee .erb .coffee.erb) + [""]
+      extensions = %w(js.coffee js.erb js.coffee.erb .js)
       file_exists?(extensions, script)
     end
 
     def stylesheet_exists?(stylesheet)
-      extensions = %w(.scss .erb .scss.erb) + [""]
+      extensions = %w(.css.scss .css.erb .css.scss.erb .css)
       file_exists?(extensions, stylesheet)
     end
 
     def file_exists?(extensions, filename)
       extensions.detect do |extension|
-        File.exists?("#{filename}.css#{extension}")
+        File.exists?("#{filename}#{extension}")
       end
     end
   end


### PR DESCRIPTION
In file_exists? method, there is a direct check of css

```
File.exists?("#{filename}.css#{extension}")
```

But this method is also called from javascript_exists? which confirms if a js file exists or not.
