### PR TITLE
assign default store when creating order from admin/api

### DIFF
--- a/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/v1/orders_controller_spec.rb
@@ -23,6 +23,19 @@ module Spree
       user
     end
 
+    shared_examples_for 'action in which order has default store assigned' do
+      it 'default store should be assigned' do
+        Spree::Store.create!(
+          name: "Jaspreet's store", code: 'jaspreet21anand',
+          url: 'vinsol.com', mail_from_address: 'jaspreet21anand@gmail.com',
+          default: true
+        )
+        expect { api_post :create }.not_to raise_error
+        order = Order.last
+        expect(order.store).to eq(Spree::Store.default)
+      end
+    end
+
     before do
       stub_authentication!
     end
@@ -244,6 +257,8 @@ module Spree
       expect(order.email).to eq(current_api_user.email)
       expect(json_response["user_id"]).to eq(current_api_user.id)
     end
+
+    it_should_behave_like 'action in which order has default store assigned'
 
     it "assigns email when creating a new order" do
       api_post :create, :order => { :email => "guest@spreecommerce.com" }
@@ -668,6 +683,8 @@ module Spree
           order = Order.last
           expect(json_response["state"]).to eq("cart")
         end
+
+        it_should_behave_like 'action in which order has default store assigned'
 
         it "can arbitrarily set the line items price" do
           api_post :create, order: {

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -128,7 +128,8 @@ module Spree
       private
         def order_params
           params[:created_by_id] = try_spree_current_user.try(:id)
-          params.permit(:created_by_id, :user_id)
+          params[:store_id] ||= current_store.id
+          params.permit(:created_by_id, :user_id, :store_id)
         end
 
         def load_order

--- a/backend/spec/controllers/spree/admin/orders_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders_controller_spec.rb
@@ -76,9 +76,21 @@ describe Spree::Admin::OrdersController, type: :controller do
 
     # Test for #3346
     context "#new" do
-      it "a new order has the current user assigned as a creator" do
+      before do
+        Spree::Store.create!(
+          name: "Jaspreet's store", code: 'jaspreet21anand',
+          url: 'vinsol.com', mail_from_address: 'jaspreet21anand@gmail.com',
+          default: true
+        )
         spree_get :new
+      end
+
+      it "a new order has the current user assigned as a creator" do
         expect(assigns[:order].created_by).to eq(controller.try_spree_current_user)
+      end
+
+      it "a new order has default store assigned when no param for store is present" do
+        expect(assigns[:order].store).to eq(Spree::Store.default)
       end
     end
 

--- a/core/lib/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/lib/spree/core/controller_helpers/strong_parameters.rb
@@ -27,7 +27,8 @@ module Spree
 
         def permitted_order_attributes
           permitted_checkout_attributes + [
-            line_items_attributes: permitted_line_item_attributes
+            line_items_attributes: permitted_line_item_attributes,
+            store_attributes: permitted_store_attributes
           ]
         end
 

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -12,6 +12,7 @@ module Spree
 
             create_params = params.slice :currency
             order = Spree::Order.create! create_params
+            order.update(store: Spree::Store.default) unless order.store
             order.associate_user!(user)
 
             shipments_attrs = params.delete(:shipments_attributes)

--- a/core/lib/spree/core/importer/order.rb
+++ b/core/lib/spree/core/importer/order.rb
@@ -12,7 +12,7 @@ module Spree
 
             create_params = params.slice :currency
             order = Spree::Order.create! create_params
-            order.update(store: Spree::Store.default) unless order.store
+            order.update!(store: Spree::Store.default) unless order.store
             order.associate_user!(user)
 
             shipments_attrs = params.delete(:shipments_attributes)

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -90,7 +90,7 @@ module Spree
     @@stock_movement_attributes = [
       :quantity, :stock_item, :stock_item_id, :originator, :action]
 
-    @@store_attributes = [:name, :url, :seo_title, :meta_keywords,
+    @@store_attributes = [:id, :name, :url, :seo_title, :meta_keywords,
                          :meta_description, :default_currency, :mail_from_address]
 
     @@store_credit_attributes = [:amount, :category_id, :memo]


### PR DESCRIPTION
No default store were assigned when we created order from admin end or from api

this rose exception in emails where url creation helpers based on stores where used

this issue was raised in spree_digital where we used to provide links for downloading in emails https://github.com/spree-contrib/spree_digital/issues/92
