### PR TITLE
Fix unshippable items issue when product has multiple stock locations , delete inventory_units if not associated to shipment or return items in create_proposed_shipments, optimise shipment modules.

### DIFF
--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -14,6 +14,7 @@ module Spree
 
     scope :backordered, -> { where state: 'backordered' }
     scope :on_hand, -> { where state: 'on_hand' }
+    scope :on_hand_or_backordered, -> { where state: ['backordered', 'on_hand'] }
     scope :shipped, -> { where state: 'shipped' }
     scope :returned, -> { where state: 'returned' }
     scope :backordered_per_variant, ->(stock_item) do

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -490,6 +490,11 @@ module Spree
     def create_proposed_shipments
       all_adjustments.shipping.delete_all
       shipments.destroy_all
+
+      # Inventory Units which are not associated to any shipment (unshippable)
+      # and are not returned or shipped should be deleted
+      inventory_units.on_hand_or_backordered.delete_all
+
       self.shipments = Spree::Stock::Coordinator.new(self).shipments
     end
 

--- a/core/app/models/spree/stock/adjuster.rb
+++ b/core/app/models/spree/stock/adjuster.rb
@@ -3,11 +3,12 @@
 module Spree
   module Stock
     class Adjuster
-      attr_accessor :inventory_unit, :status, :fulfilled
+      attr_accessor :inventory_unit, :status, :fulfilled, :package
 
-      def initialize(inventory_unit, status)
+      def initialize(inventory_unit, status, package=nil)
         @inventory_unit = inventory_unit
         @status = status
+        @package = package
         @fulfilled = false
       end
 

--- a/core/app/models/spree/stock/inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/inventory_unit_builder.rb
@@ -10,8 +10,8 @@ module Spree
           line_item.quantity.times.map do |i|
             @order.inventory_units.build(
               pending: true,
-              variant: line_item.variant,
-              line_item: line_item,
+              variant_id: line_item.variant_id,
+              line_item_id: line_item.id,
               order: @order
             )
           end

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -11,7 +11,8 @@ module Spree
       end
 
       def add(inventory_unit, state = :on_hand)
-        contents << ContentItem.new(inventory_unit, state) unless find_item(inventory_unit)
+        # Remove find_item check as already taken care by prioritizer
+        contents << ContentItem.new(inventory_unit, state)
       end
 
       def add_multiple(inventory_units, state = :on_hand)
@@ -62,11 +63,12 @@ module Spree
       end
 
       def shipping_categories
-        contents.map { |item| item.variant.shipping_category }.compact.uniq
+        Spree::ShippingCategory.joins(products: :variants_including_master).
+          where(spree_variants: { id: variant_ids }).uniq
       end
 
       def shipping_methods
-        shipping_categories.map(&:shipping_methods).reduce(:&).to_a
+        shipping_categories.includes(:shipping_methods).map(&:shipping_methods).reduce(:&).to_a
       end
 
       def inspect
@@ -98,6 +100,12 @@ module Spree
 
       def dimension
         contents.sum(&:dimension)
+      end
+
+      private
+
+      def variant_ids
+        contents.map { |item| item.inventory_unit.variant_id }.compact.uniq
       end
     end
   end

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -1,12 +1,13 @@
 module Spree
   module Stock
     class Packer
-      attr_reader :stock_location, :inventory_units, :splitters
+      attr_reader :stock_location, :inventory_units, :splitters, :allocated_inventory_units
 
       def initialize(stock_location, inventory_units, splitters=[Splitter::Base])
         @stock_location = stock_location
         @inventory_units = inventory_units
         @splitters = splitters
+        @allocated_inventory_units = []
       end
 
       def packages
@@ -19,23 +20,32 @@ module Spree
 
       def default_package
         package = Package.new(stock_location)
-        inventory_units.group_by(&:variant).each do |variant, variant_inventory_units|
+
+        # Group by variant_id as grouping by variant fires cached query.
+        inventory_units.group_by(&:variant_id).each do |variant_id, variant_inventory_units|
+          variant = Spree::Variant.find(variant_id)
           units = variant_inventory_units.clone
           if variant.should_track_inventory?
             next unless stock_location.stock_item(variant)
 
             on_hand, backordered = stock_location.fill_status(variant, units.size)
-            package.add_multiple units.slice!(0, on_hand), :on_hand if on_hand > 0
-            package.add_multiple units.slice!(0, backordered), :backordered if backordered > 0
+            on_hand_units, backordered_units = units.slice!(0, on_hand), units.slice!(0, backordered)
+
+            package.add_multiple on_hand_units, :on_hand if on_hand > 0
+            package.add_multiple backordered_units, :backordered if backordered > 0
+
+            @allocated_inventory_units += (on_hand_units + backordered_units)
           else
             package.add_multiple units
+            @allocated_inventory_units += units
           end
-
         end
+
         package
       end
 
       private
+
       def build_splitter
         splitter = nil
         splitters.reverse.each do |klass|

--- a/core/app/models/spree/stock/prioritizer.rb
+++ b/core/app/models/spree/stock/prioritizer.rb
@@ -1,12 +1,12 @@
 module Spree
   module Stock
     class Prioritizer
-      attr_reader :packages, :inventory_units
+      attr_reader :packages
 
-      def initialize(inventory_units, packages, adjuster_class=Adjuster)
-        @inventory_units = inventory_units
+      def initialize(packages, adjuster_class=Adjuster)
         @packages = packages
         @adjuster_class = adjuster_class
+        @adjusters = Hash.new
       end
 
       def prioritized_packages
@@ -17,22 +17,34 @@ module Spree
       end
 
       private
+
       def adjust_packages
-        inventory_units.each do |inventory_unit|
-          adjuster = @adjuster_class.new(inventory_unit, :on_hand)
+        packages.each do |package|
+          package.contents.each do |item|
+            adjuster = find_adjuster(item)
 
-          visit_packages(adjuster)
+            if adjuster.nil?
+              adjuster = build_adjuster(item, package)
 
-          adjuster.status = :backordered
-          visit_packages(adjuster)
+            elsif item.state == :on_hand && adjuster.status == :backordered
+              # Adjust old package content if it was backordered and reassign package and state
+              old_package = adjuster.package
+              adjuster.package, adjuster.status = package, :on_hand
+
+              package = old_package
+            end
+
+            adjuster.adjust(package)
+          end
         end
       end
 
-      def visit_packages(adjuster)
-        packages.each do |package|
-          item = package.find_item adjuster.inventory_unit, adjuster.status
-          adjuster.adjust(package) if item
-        end
+      def build_adjuster(item, package)
+        @adjusters[item.inventory_unit] = @adjuster_class.new(item.inventory_unit, item.state, package)
+      end
+
+      def find_adjuster(item)
+        @adjusters[item.inventory_unit]
       end
 
       def sort_packages

--- a/core/app/models/spree/stock/splitter/shipping_category.rb
+++ b/core/app/models/spree/stock/splitter/shipping_category.rb
@@ -14,7 +14,7 @@ module Spree
         def split_by_category(package)
           categories = Hash.new { |hash, key| hash[key] = [] }
           package.contents.each do |item|
-            categories[item.variant.shipping_category_id] << item
+            categories[ shipping_category_for(item) ] << item
           end
           hash_to_packages(categories)
         end
@@ -25,6 +25,11 @@ module Spree
             packages << build_package(contents)
           end
           packages
+        end
+
+        def shipping_category_for(item)
+          @item_shipping_category ||= {}
+          @item_shipping_category[item.inventory_unit.variant_id] ||= item.variant.shipping_category_id
         end
       end
     end

--- a/core/spec/models/spree/inventory_unit_spec.rb
+++ b/core/spec/models/spree/inventory_unit_spec.rb
@@ -4,6 +4,33 @@ describe Spree::InventoryUnit, :type => :model do
   let(:stock_location) { create(:stock_location_with_items) }
   let(:stock_item) { stock_location.stock_items.order(:id).first }
 
+  describe 'scopes' do
+    let!(:inventory_unit_1) { create(:inventory_unit, state: 'on_hand') }
+    let!(:inventory_unit_2) { create(:inventory_unit, state: 'backordered') }
+    let!(:inventory_unit_3) { create(:inventory_unit, state: 'shipped') }
+    let!(:inventory_unit_4) { create(:inventory_unit, state: 'returned') }
+
+    describe '.backordered' do
+      it { expect(Spree::InventoryUnit.backordered).to eq([inventory_unit_2]) }
+    end
+
+    describe '.on_hand' do
+      it { expect(Spree::InventoryUnit.on_hand).to eq([inventory_unit_1]) }
+    end
+
+    describe '.on_hand_or_backordered' do
+      it { expect(Spree::InventoryUnit.on_hand_or_backordered).to eq([inventory_unit_1, inventory_unit_2]) }
+    end
+
+    describe '.shipped' do
+      it { expect(Spree::InventoryUnit.shipped).to eq([inventory_unit_3]) }
+    end
+
+    describe '.returned' do
+      it { expect(Spree::InventoryUnit.returned).to eq([inventory_unit_4]) }
+    end
+  end
+
   context "#backordered_for_stock_item" do
     let(:order) do
       order = create(:order, state: 'complete', ship_address: create(:ship_address))

--- a/core/spec/models/spree/stock/coordinator_spec.rb
+++ b/core/spec/models/spree/stock/coordinator_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Spree
   module Stock
     describe Coordinator, :type => :model do
-      let!(:order) { create(:order_with_line_items) }
+      let(:order) { create(:order_with_line_items) }
 
       subject { Coordinator.new(order) }
 
@@ -34,8 +34,18 @@ module Spree
       end
 
       context "build packages" do
+        let!(:stock_location1) { create(:stock_location, backorderable_default: false) }
+        let!(:stock_location2) { create(:stock_location, backorderable_default: false) }
+        let!(:product) { create(:product) }
+
+        let!(:order) do
+          product.stock_items.map { |stock_item| stock_item.adjust_count_on_hand(1) }
+          line_item = create(:line_item, product: product, quantity: 2)
+          line_item.order
+        end
+
         it "builds a package for every stock location" do
-          subject.packages.count == StockLocation.count
+          expect(subject.build_packages.count).to eq(StockLocation.count)
         end
 
         context "missing stock items in stock location" do

--- a/core/spec/models/spree/stock/inventory_unit_builder_spec.rb
+++ b/core/spec/models/spree/stock/inventory_unit_builder_spec.rb
@@ -13,14 +13,14 @@ module Spree
         it "returns an inventory unit for each quantity for the order's line items" do
           units = subject.units
           expect(units.count).to eq 3
-          expect(units.first.line_item).to eq line_item_1
-          expect(units.first.variant).to eq line_item_1.variant
+          expect(units.first.line_item_id).to eq line_item_1.id
+          expect(units.first.variant_id).to eq line_item_1.variant_id
 
-          expect(units[1].line_item).to eq line_item_2
-          expect(units[1].variant).to eq line_item_2.variant
+          expect(units[1].line_item_id).to eq line_item_2.id
+          expect(units[1].variant_id).to eq line_item_2.variant_id
 
-          expect(units[2].line_item).to eq line_item_2
-          expect(units[2].variant).to eq line_item_2.variant
+          expect(units[2].line_item_id).to eq line_item_2.id
+          expect(units[2].variant_id).to eq line_item_2.variant_id
         end
 
         it "builds the inventory units as pending" do

--- a/core/spec/models/spree/stock/package_spec.rb
+++ b/core/spec/models/spree/stock/package_spec.rb
@@ -13,6 +13,10 @@ module Spree
         build(:inventory_unit, variant: variant)
       end
 
+      def create_inventory_unit
+        create(:inventory_unit, variant: variant)
+      end
+
       it 'calculates the weight of all the contents' do
         4.times { subject.add build_inventory_unit }
         expect(subject.weight).to eq(100.0)
@@ -64,13 +68,12 @@ module Spree
         method2   = create(:shipping_method)
         method1.shipping_categories = [category1, category2]
         method2.shipping_categories = [category1]
-        variant1 = mock_model(Variant, shipping_category: category1)
-        variant2 = mock_model(Variant, shipping_category: category2)
-        variant3 = mock_model(Variant, shipping_category: nil)
-        contents = [ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant1)),
-                    ContentItem.new(build(:inventory_unit, variant: variant2)),
-                    ContentItem.new(build(:inventory_unit, variant: variant3))]
+        variant1 = create(:product, shipping_category: category1).master
+        variant2 = create(:product, shipping_category: category2).master
+
+        contents = [ContentItem.new(build(:inventory_unit, variant_id: variant1.id)),
+                    ContentItem.new(build(:inventory_unit, variant_id: variant1.id)),
+                    ContentItem.new(build(:inventory_unit, variant_id: variant2.id))]
 
         package = Package.new(stock_location, contents)
         expect(package.shipping_methods).to eq([method1])
@@ -104,16 +107,6 @@ module Spree
         expect(last_unit.state).to eq 'backordered'
 
         expect(shipment.shipping_method).to eq shipping_method
-      end
-
-      it 'does not add an inventory unit to a package twice' do
-        # since inventory units currently don't have a quantity
-        unit = build_inventory_unit
-        subject.add unit
-        subject.add unit
-        expect(subject.quantity).to eq 1
-        expect(subject.contents.first.inventory_unit).to eq unit
-        expect(subject.contents.first.quantity).to eq 1
       end
 
       describe "#add_multiple" do

--- a/core/spec/models/spree/stock/prioritizer_spec.rb
+++ b/core/spec/models/spree/stock/prioritizer_spec.rb
@@ -30,7 +30,7 @@ module Spree
         end
 
         packages = [package1]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
         expect(packages.size).to eq 1
       end
@@ -47,7 +47,7 @@ module Spree
         end
 
         packages = [package1, package2]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
         expect(packages.size).to eq 1
       end
@@ -61,7 +61,7 @@ module Spree
         end
 
         packages = [package1, package2]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
         expect(packages.size).to eq 2
       end
@@ -77,7 +77,7 @@ module Spree
         end
 
         packages = [package1, package2]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
         expect(packages.count).to eq 2
         expect(packages[0].quantity).to eq 2
@@ -95,7 +95,7 @@ module Spree
         end
 
         packages = [package1, package2]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
 
         expect(packages[0].quantity(:backordered)).to eq 3
@@ -113,7 +113,7 @@ module Spree
         end
 
         packages = [package1, package2]
-        prioritizer = Prioritizer.new(inventory_units, packages)
+        prioritizer = Prioritizer.new(packages)
         packages = prioritizer.prioritized_packages
         expect(packages[0]).to eq package2
         expect(packages[1]).to be_nil

--- a/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
+++ b/core/spec/models/spree/stock/splitter/shipping_category_spec.rb
@@ -5,8 +5,8 @@ module Spree
     module Splitter
       describe ShippingCategory, :type => :model do
 
-        let(:variant1) { build(:variant) }
-        let(:variant2) { build(:variant) }
+        let(:variant1) { create(:variant) }
+        let(:variant2) { create(:variant) }
         let(:shipping_category_1) { create(:shipping_category, name: 'A') }
         let(:shipping_category_2) { create(:shipping_category, name: 'B') }
 


### PR DESCRIPTION
Fixes 2 shipment issues, and optimises shipment modules like Coordinator, Prioritizer, Packer etc..

**Issue 1**
- Scenario: A product has 2 stock items for 2 stock locations. Each stock item has 1 quantity on hand and none is backorderable. User adds 2 quantity of that item in cart and moves to delivery step. Sees a shipment and an unshippable unit.
- Expected: User should see 2 shipments (no unshippable unit) each having 1 associated inventory unit.

**Issue 2**
- In `order#create_proposed_shipments`, inventory units are destroyed using shipments `has_many inventory_units, dependent: :delete_all` association but units which are not associated to any shipment (like unshippable units) are never destroyed.
