### PR TITLE
Delayed inventory units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 \#*
 **/*.db
 **/*.log
+**/*.byebug_history
 *~
 .#*
 .DS_Store

--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -48,7 +48,7 @@ module Spree
         end
 
         def load_order
-          @order = Order.includes(:adjustments).friendly.find(params[:order_id])
+          @order = Order.editable.includes(:adjustments).friendly.find(params[:order_id])
         end
 
         def model_class

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -34,7 +34,7 @@ module Spree
           params[:q][:completed_at_lt] = params[:q].delete(:created_at_lt)
         end
 
-        @search = Order.preload(:user).accessible_by(current_ability, :index).ransack(params[:q])
+        @search = Order.editable.preload(:user).accessible_by(current_ability, :index).ransack(params[:q])
 
         # lazy loading other models here (via includes) may result in an invalid query
         # e.g. SELECT  DISTINCT DISTINCT "spree_orders".id, "spree_orders"."created_at" AS alias_0 FROM "spree_orders"
@@ -130,7 +130,7 @@ module Spree
         end
 
         def load_order
-          @order = Order.includes(:adjustments).friendly.find(params[:id])
+          @order = Order.editable.includes(:adjustments).friendly.find(params[:id])
           authorize! action, @order
         end
 

--- a/core/app/jobs/spree/application_job.rb
+++ b/core/app/jobs/spree/application_job.rb
@@ -1,0 +1,4 @@
+module Spree
+  class ApplicationJob < ActiveJob::Base
+  end
+end

--- a/core/app/jobs/spree/finalize_order_job.rb
+++ b/core/app/jobs/spree/finalize_order_job.rb
@@ -1,0 +1,10 @@
+module Spree
+  class FinalizeOrderJob < ApplicationJob
+    queue_as :default
+
+    def perform(order_id)
+      order = Order.find(order_id)
+      order.finalize_shipments!
+    end
+  end
+end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -374,6 +374,8 @@ module Spree
       touch :completed_at
 
       deliver_order_confirmation_email unless confirmation_delivered?
+      allot_content_items_to_shipment_proposal
+      shipments.each(&:pre_finalize)
 
       consider_risk
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -152,6 +152,7 @@ module Spree
     scope :completed_between, ->(start_date, end_date) { where(completed_at: start_date..end_date) }
     scope :complete, -> { where.not(completed_at: nil) }
     scope :incomplete, -> { where(completed_at: nil) }
+    scope :editable,   -> { where(processing_shipments: false) }
 
     # shows completed orders first, by their completed_at date, then uncompleted orders by their created_at
     scope :reverse_chronological, -> { order('spree_orders.completed_at IS NULL', completed_at: :desc, created_at: :desc) }
@@ -378,12 +379,23 @@ module Spree
     end
 
     def finalize_shipments!
-      shipments.each do |shipment|
-        shipment.update!(self)
-        shipment.finalize!
-      end
+      transaction do
+        shipments.each do |shipment|
+          shipment.update!(self)
+          shipment.finalize!
+        end
 
-      updater.update_shipment_state
+        updater.update_shipment_state
+        release_processing_shipments_lock
+      end
+    end
+
+    def acquire_processing_shipments_lock
+      update_column(:processing_shipments, true)
+    end
+
+    def release_processing_shipments_lock
+      update_column(:processing_shipments, false)
     end
 
     def fulfill!

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -495,13 +495,11 @@ module Spree
     end
 
     def allot_inventory_units_to_shipment_proposal
-      existing_shipments = shipments
-      shipment_with_inventory_units = Spree::Stock::Coordinator.new(self).shipments
-      shipments.each do |_shipment|
-        matching_shipment = shipment_with_inventory_units.detect { |x| x.stock_location == _shipment.stock_location }
-        _shipment.inventory_units = matching_shipment.inventory_units
-        shipment_with_inventory_units -= [matching_shipment]
-      end
+      Stock::ShipmentAllocator.new(self).allocate_inventory_units
+    end
+
+    def allot_content_items_to_shipment_proposal
+      Stock::ShipmentAllocator.new(self).allocate_proposal_content
     end
 
     def create_proposed_shipments

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -374,8 +374,6 @@ module Spree
       touch :completed_at
 
       deliver_order_confirmation_email unless confirmation_delivered?
-      allot_content_items_to_shipment_proposal
-      shipments.each(&:pre_finalize)
 
       consider_risk
     end

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -361,7 +361,7 @@ module Spree
 
     # Finalizes an in progress order after checkout is complete.
     # Called after transition to complete state when payments will have been processed
-     def finalize!
+    def finalize!
       # lock all adjustments (coupon promotions, etc.)
       all_adjustments.each{|a| a.close}
 
@@ -375,16 +375,16 @@ module Spree
       deliver_order_confirmation_email unless confirmation_delivered?
 
       consider_risk
-     end
+    end
 
-     def finalize_shipments!
-       shipments.each do |shipment|
+    def finalize_shipments!
+      shipments.each do |shipment|
         shipment.update!(self)
         shipment.finalize!
       end
 
       updater.update_shipment_state
-     end
+    end
 
     def fulfill!
       shipments.each { |shipment| shipment.update!(self) if shipment.persisted? }

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -379,15 +379,13 @@ module Spree
     end
 
     def finalize_shipments!
-      transaction do
-        shipments.each do |shipment|
-          shipment.update!(self)
-          shipment.finalize!
-        end
-
-        updater.update_shipment_state
-        release_processing_shipments_lock
+      shipments.each do |shipment|
+        shipment.update!(self)
+        shipment.finalize!
       end
+
+      updater.update_shipment_state
+      release_processing_shipments_lock
     end
 
     def acquire_processing_shipments_lock
@@ -513,10 +511,6 @@ module Spree
       # and are not returned or shipped should be deleted
       inventory_units.on_hand_or_backordered.delete_all
       self.shipments = Spree::Stock::ProposalCoordinator.new(self).shipments
-    end
-
-    def create_final_shipments
-      self.shipments = Spree::Stock::Coordinator.new(self).shipments
     end
 
     def apply_free_shipping_promotions

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -379,6 +379,7 @@ module Spree
     end
 
     def finalize_shipments!
+      allot_inventory_units_to_shipment_proposal
       shipments.each do |shipment|
         shipment.update!(self)
         shipment.finalize!
@@ -491,6 +492,16 @@ module Spree
 
     def shipped?
       %w(partial shipped).include?(shipment_state)
+    end
+
+    def allot_inventory_units_to_shipment_proposal
+      existing_shipments = shipments
+      shipment_with_inventory_units = Spree::Stock::Coordinator.new(self).shipments
+      shipments.each do |_shipment|
+        matching_shipment = shipment_with_inventory_units.detect { |x| x.stock_location == _shipment.stock_location }
+        _shipment.inventory_units = matching_shipment.inventory_units
+        shipment_with_inventory_units -= [matching_shipment]
+      end
     end
 
     def create_proposed_shipments

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -487,8 +487,17 @@ module Spree
       # Inventory Units which are not associated to any shipment (unshippable)
       # and are not returned or shipped should be deleted
       inventory_units.on_hand_or_backordered.delete_all
-
       self.shipments = Spree::Stock::Coordinator.new(self).shipments
+    end
+
+    def create_proposed_shipments_for_delivery
+      all_adjustments.shipping.delete_all
+      shipments.destroy_all
+
+      # Inventory Units which are not associated to any shipment (unshippable)
+      # and are not returned or shipped should be deleted
+      inventory_units.on_hand_or_backordered.delete_all
+      self.shipments = Spree::Stock::ProposalCoordinator.new(self).shipments
     end
 
     def apply_free_shipping_promotions

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -101,7 +101,7 @@ module Spree
               end
 
               if states[:delivery]
-                before_transition to: :delivery, do: :create_proposed_shipments
+                before_transition to: :delivery, do: :create_proposed_shipments_for_delivery
                 before_transition to: :delivery, do: :ensure_available_shipping_rates
                 before_transition to: :delivery, do: :set_shipments_cost
                 before_transition from: :delivery, do: :apply_free_shipping_promotions

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -112,6 +112,7 @@ module Spree
 
               after_transition to: :complete do |order|
                 order.finalize!
+                order.acquire_processing_shipments_lock
                 FinalizeOrderJob.perform_later order.id
               end
               after_transition to: :resumed, do: :after_resume

--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -110,7 +110,10 @@ module Spree
               before_transition to: :resumed, do: :ensure_line_item_variants_are_not_discontinued
               before_transition to: :resumed, do: :ensure_line_items_are_in_stock
 
-              after_transition to: :complete, do: :finalize!
+              after_transition to: :complete do |order|
+                order.finalize!
+                FinalizeOrderJob.perform_later order.id
+              end
               after_transition to: :resumed, do: :after_resume
               after_transition to: :canceled, do: :after_cancel
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -145,8 +145,10 @@ module Spree
     end
 
     def create_inventory_units
-      to_package.contents.each do |content|
-        content.quantity.times { self.inventory_units.new(state: content.state, variant: content.variant, order_id: order_id, line_item: content.line_item).save }
+      transaction do
+        to_package.contents.each do |content|
+          content.quantity.times { InventoryUnit.create(state: content.state, variant: content.variant, order_id: order_id, line_item: content.line_item, shipment: self) }
+        end
       end
     end
 

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -139,8 +139,15 @@ module Spree
     end
 
     def finalize!
+      create_inventory_units
       inventory_units.finalize_units!
       after_resume
+    end
+
+    def create_inventory_units
+      to_package.contents.each do |content|
+        content.quantity.times { self.inventory_units.new(state: content.state, variant: content.variant, order_id: order_id, line_item: content.line_item).save }
+      end
     end
 
     def include?(variant)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -30,6 +30,7 @@ module Spree
     validates :stock_location, presence: true
 
     attr_accessor :special_instructions
+    attr_accessor :package_contents
 
     accepts_nested_attributes_for :address
     accepts_nested_attributes_for :inventory_units
@@ -166,6 +167,8 @@ module Spree
     ManifestItem = Struct.new(:line_item, :variant, :quantity, :states)
 
     def manifest
+      return manifest_from_package_contents if inventory_units.none? && package_contents.present?
+
       # Grouping by the ID means that we don't have to call out to the association accessor
       # This makes the grouping by faster because it results in less SQL cache hits.
       inventory_units.group_by(&:variant_id).map do |variant_id, units|
@@ -177,6 +180,18 @@ module Spree
           line_item = units.first.line_item
           variant = units.first.variant
           ManifestItem.new(line_item, variant, units.length, states)
+        end
+      end.flatten
+    end
+
+    def manifest_from_package_contents
+      package_contents.group_by(&:variant_id).map do |variant_id, contents|
+        contents.group_by(&:line_item_id).map do |line_item_id, units|
+          states = {}
+          units.group_by(&:state).each { |state, unit| states[state] = unit.sum(&:quantity) }
+          line_item = units.first.line_item
+          variant   = units.first.variant
+          ManifestItem.new(line_item, variant, units.sum(&:quantity), states)
         end
       end.flatten
     end
@@ -271,9 +286,9 @@ module Spree
     end
 
     def to_package
-      if inventory_units.none?
+      if inventory_units.none? && package_contents.present?
         # Send the proposal package back
-        Stock::ProposalPacker.new(stock_location, Stock::ProposalInventoryUnitBuilder.new(order).units).packages.first
+        Stock::Package.new(stock_location, package_contents)
       else
         package = Stock::Package.new(stock_location)
         inventory_units.includes(:variant).joins(:variant).group_by(&:state).each do |state, state_inventory_units|

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -101,10 +101,6 @@ module Spree
       manifest.each { |item| manifest_unstock(item) }
     end
 
-    def pre_finalize
-      manifest.each { |item| manifest_unstock(item) }
-    end
-
     def backordered?
       inventory_units.any? { |inventory_unit| inventory_unit.backordered? }
     end
@@ -145,6 +141,7 @@ module Spree
 
     def finalize!
       inventory_units.finalize_units!
+      after_resume
     end
 
     def include?(variant)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -271,11 +271,7 @@ module Spree
     end
 
     def to_package
-      package = Stock::Package.new(stock_location)
-      inventory_units.includes(:variant).joins(:variant).group_by(&:state).each do |state, state_inventory_units|
-        package.add_multiple state_inventory_units, state.to_sym
-      end
-      package
+      Stock::ProposalPacker.new(stock_location, Stock::ProposalInventoryUnitBuilder.new(order).units).packages.first
     end
 
     def tracking_url

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -150,6 +150,7 @@ module Spree
           content.quantity.times { InventoryUnit.create(state: content.state, variant: content.variant, order_id: order_id, line_item: content.line_item, shipment: self) }
         end
       end
+      inventory_units.reload # They are created seperately load them since they won't be in memory
     end
 
     def include?(variant)

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -139,18 +139,8 @@ module Spree
     end
 
     def finalize!
-      create_inventory_units
       inventory_units.finalize_units!
       after_resume
-    end
-
-    def create_inventory_units
-      transaction do
-        to_package.contents.each do |content|
-          content.quantity.times { InventoryUnit.create(state: content.state, variant: content.variant, order_id: order_id, line_item: content.line_item, shipment: self) }
-        end
-      end
-      inventory_units.reload # They are created seperately load them since they won't be in memory
     end
 
     def include?(variant)

--- a/core/app/models/spree/stock/content_item.rb
+++ b/core/app/models/spree/stock/content_item.rb
@@ -19,6 +19,7 @@ module Spree
                  :shipping_category_id, to: :variant
 
         delegate :order, to: :line_item
+        delegate :id, to: :line_item, prefix: true
 
         delegate :dimension,
                  :volume,

--- a/core/app/models/spree/stock/content_item.rb
+++ b/core/app/models/spree/stock/content_item.rb
@@ -6,10 +6,8 @@ module Spree
       def initialize(inventory_unit, state = :on_hand)
         @inventory_unit = inventory_unit
         @state = state
-        # Since inventory units don't have a quantity,
-        # make this always 1 for now, leaving ourselves
-        # open to a different possibility in the future,
-        # but this massively simplifies things for now
+        # Quantity will be > 1, if proposed to ease db pressure while building shipments
+        # after order is completed it will be used by a delayed job to build the actual inventory units
         @quantity = 1
       end
 
@@ -46,6 +44,11 @@ module Spree
 
       def dimension
         variant_dimension * quantity
+      end
+
+      def inventory_unit_with_state
+        inventory_unit.state = state.to_s
+        inventory_unit
       end
     end
   end

--- a/core/app/models/spree/stock/content_item.rb
+++ b/core/app/models/spree/stock/content_item.rb
@@ -1,19 +1,26 @@
 module Spree
   module Stock
     class ContentItem
-      attr_accessor :inventory_unit, :state
+      attr_accessor :inventory_unit, :state, :quantity
 
       def initialize(inventory_unit, state = :on_hand)
         @inventory_unit = inventory_unit
         @state = state
+        # Since inventory units don't have a quantity,
+        # make this always 1 for now, leaving ourselves
+        # open to a different possibility in the future,
+        # but this massively simplifies things for now
+        @quantity = 1
       end
 
       with_options allow_nil: true do
         delegate :line_item,
                  :variant, to: :inventory_unit
-        delegate :price, to: :variant
+        delegate :price,
+                 :shipping_category_id, to: :variant
         delegate :dimension,
                  :volume,
+                 :id,
                  :weight, to: :variant, prefix: true
       end
 
@@ -29,17 +36,8 @@ module Spree
         state.to_s == "backordered"
       end
 
-
       def amount
         price * quantity
-      end
-
-      def quantity
-        # Since inventory units don't have a quantity,
-        # make this always 1 for now, leaving ourselves
-        # open to a different possibility in the future,
-        # but this massively simplifies things for now
-        1
       end
 
       def volume

--- a/core/app/models/spree/stock/content_item.rb
+++ b/core/app/models/spree/stock/content_item.rb
@@ -14,8 +14,12 @@ module Spree
       with_options allow_nil: true do
         delegate :line_item,
                  :variant, to: :inventory_unit
+
         delegate :price,
                  :shipping_category_id, to: :variant
+
+        delegate :order, to: :line_item
+
         delegate :dimension,
                  :volume,
                  :id,
@@ -24,6 +28,14 @@ module Spree
 
       def weight
         variant_weight * quantity
+      end
+
+      def remove_quantity(quantity_to_remove = 1)
+        self.quantity = quantity - quantity_to_remove
+      end
+
+      def empty?
+        quantity == 0
       end
 
       def on_hand?
@@ -49,6 +61,10 @@ module Spree
       def inventory_unit_with_state
         inventory_unit.state = state.to_s
         inventory_unit
+      end
+
+      def contains_inventory_unit?(inventory_unit, state = nil)
+        (inventory_unit.variant == self.variant) && (state.nil? || state.to_s == self.state.to_s)
       end
     end
   end

--- a/core/app/models/spree/stock/inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/inventory_unit_builder.rb
@@ -11,8 +11,7 @@ module Spree
             @order.inventory_units.build(
               pending: true,
               variant_id: line_item.variant_id,
-              line_item: line_item,
-              order: @order
+              line_item: line_item
             )
           end
         end

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -104,6 +104,10 @@ module Spree
         shipment
       end
 
+      def to_proposed_shipment
+        ProposedShipment.new(stock_location, contents)
+      end
+
       def contents_by_weight
         contents.sort { |x, y| y.weight <=> x.weight }
       end

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -105,7 +105,7 @@ module Spree
       private
 
       def variant_ids
-        contents.map { |item| item.inventory_unit.variant_id }.compact.uniq
+        contents.map { |item| item.variant_id }.compact.uniq
       end
     end
   end

--- a/core/app/models/spree/stock/prioritizer.rb
+++ b/core/app/models/spree/stock/prioritizer.rb
@@ -27,7 +27,7 @@ module Spree
               adjuster = build_adjuster(item, package)
             elsif item.state == :on_hand && adjuster.status == :backordered
               # Remove item from backordered package
-              adjuster.package.remove(item.inventory_unit)
+              adjuster.package.remove(item.inventory_unit, item.quantity)
               # Reassign adjuster's status package
               adjuster.reassign(:on_hand, package)
             end

--- a/core/app/models/spree/stock/proposal_coordinator.rb
+++ b/core/app/models/spree/stock/proposal_coordinator.rb
@@ -1,0 +1,29 @@
+module Spree
+  module Stock
+    class ProposalCoordinator < Coordinator
+      def initialize(order)
+        @order = order
+        @inventory_units = ProposalInventoryUnitBuilder.new(order).units
+        @allocated_inventory_units = []
+      end
+
+      def packages
+        super.collect(&:as_proposed)
+      end
+
+      private
+
+      def unallocated_inventory_units
+        inventory_units.unallocated_units
+      end
+
+      def requested_variant_ids
+        @inventory_units.variant_ids
+      end
+
+      def build_packer(stock_location, inventory_units)
+        ProposalPacker.new(stock_location, inventory_units, splitters(stock_location))
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/proposal_coordinator.rb
+++ b/core/app/models/spree/stock/proposal_coordinator.rb
@@ -8,7 +8,11 @@ module Spree
       end
 
       def packages
-        super.collect(&:as_proposed)
+        estimate_packages(build_packages).collect(&:as_proposed)
+      end
+
+      def proposed_shipments
+        packages.collect(&:to_proposed_shipment)
       end
 
       private

--- a/core/app/models/spree/stock/proposal_inventory_unit_builder.rb
+++ b/core/app/models/spree/stock/proposal_inventory_unit_builder.rb
@@ -1,0 +1,70 @@
+module Spree
+  module Stock
+    class ProposalInventoryUnits
+      attr_accessor :units, :variants
+
+      def initialize(units, variants)
+        self.units    = units
+        self.variants = variants
+        @allocated    = [].to_set
+      end
+
+      def by_variant_id
+        unallocated_units.units
+      end
+
+      def mark_variant_as_allocated(variant_id)
+        @allocated << variant_id
+      end
+
+      def unallocated_units
+        unallocated_variants = self.variants - @allocated
+        unallocated_units    = @units.slice(*unallocated_variants.to_a)
+        self.class.new(unallocated_units, unallocated_variants)
+      end
+
+      def variant_ids
+        self.variants.to_a
+      end
+
+      class << self
+        def from_line_items(line_items)
+          units    = build_units_from_line_items(line_items)
+          variants = units.keys.to_set
+          new(units, variants)
+        end
+
+        private
+        def build_units_from_line_items(line_items)
+          line_items.inject({}) do |acc, ln_item|
+            acc[ln_item.variant_id] = ProposalInventoryUnit.new(ln_item.variant, ln_item, ln_item.quantity)
+            acc
+          end
+        end
+      end
+    end
+
+    class ProposalInventoryUnit
+      attr_accessor :count, :variant, :state, :line_item
+      alias_method  :size, :count
+
+      def initialize(variant, line_item, count)
+        self.variant = variant
+        self.line_item = line_item
+        self.count = count
+      end
+    end
+
+    class ProposalInventoryUnitBuilder
+      attr_accessor :order
+
+      def initialize(order)
+        self.order = order
+      end
+
+      def units
+        ProposalInventoryUnits.from_line_items(order.line_items)
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/proposal_packer.rb
+++ b/core/app/models/spree/stock/proposal_packer.rb
@@ -1,0 +1,25 @@
+module Spree
+  module Stock
+    class ProposalPacker < Packer
+      # Works with proposed inventory units, which only behaves like a collection and is never persisted
+
+      def default_package
+        package = Package.new(stock_location)
+        inventory_units.by_variant_id.each do |variant_id, variant_inventory_units|
+          variant = Spree::Variant.find(variant_id)
+          if variant.should_track_inventory?
+            next unless stock_location.stock_item(variant)
+            on_hand_count, backordered_count = stock_location.fill_status(variant, variant_inventory_units.size)
+            package.add_multiple_for_proposal(variant_inventory_units, on_hand_count, :on_hand)       if on_hand_count > 0
+            package.add_multiple_for_proposal(variant_inventory_units, backordered_count, :backordered) if backordered_count > 0
+            inventory_units.mark_variant_as_allocated(variant)
+          else
+            package.add_multiple_for_proposal(variant_inventory_units, variant_inventory_units.count, :on_hand)
+            inventory_units.mark_variant_as_allocated(variant_id)
+          end
+        end
+        package
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/proposal_packer.rb
+++ b/core/app/models/spree/stock/proposal_packer.rb
@@ -10,7 +10,7 @@ module Spree
           if variant.should_track_inventory?
             next unless stock_location.stock_item(variant)
             on_hand_count, backordered_count = stock_location.fill_status(variant, variant_inventory_units.size)
-            package.add_multiple_for_proposal(variant_inventory_units, on_hand_count, :on_hand)       if on_hand_count > 0
+            package.add_multiple_for_proposal(variant_inventory_units, on_hand_count, :on_hand)         if on_hand_count > 0
             package.add_multiple_for_proposal(variant_inventory_units, backordered_count, :backordered) if backordered_count > 0
             inventory_units.mark_variant_as_allocated(variant)
           else

--- a/core/app/models/spree/stock/proposed_shipment.rb
+++ b/core/app/models/spree/stock/proposed_shipment.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Stock
+    class ProposedShipment
+      attr_accessor :contents, :stock_location
+      def initialize(stock_location, contents)
+        self.contents = contents
+        self.stock_location = stock_location
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/shipment_allocator.rb
+++ b/core/app/models/spree/stock/shipment_allocator.rb
@@ -12,7 +12,7 @@ module Spree
       def allocate_proposal_content
         shipments.each do |_shipment|
           match = next_proposed_match(_shipment)
-          _shipment.package_contents = match.contents
+          _shipment.proposed_package_contents = match.contents
         end
       end
 

--- a/core/app/models/spree/stock/shipment_allocator.rb
+++ b/core/app/models/spree/stock/shipment_allocator.rb
@@ -1,0 +1,48 @@
+module Spree
+  module Stock
+    class ShipmentAllocator
+
+      attr_accessor :order, :shipments
+
+      def initialize(order)
+        self.order = order
+        self.shipments = order.shipments
+      end
+
+      def allocate_proposal_content
+        shipments.each do |_shipment|
+          match = next_proposed_match(_shipment)
+          _shipment.package_contents = match.contents
+        end
+      end
+
+      def allocate_inventory_units
+        shipments.each do |_shipment|
+          match = next_match(_shipment)
+          _shipment.inventory_units = match.inventory_units
+        end
+      end
+
+      private
+      def next_proposed_match(shipment)
+        m = proposed_shipments.detect { |x| x.stock_location == shipment.stock_location }
+        @proposed = proposed_shipments - [m]
+        m
+      end
+
+      def next_match(shipment)
+        m = shipments_with_inventory_units.detect { |x| x.stock_location == shipment.stock_location }
+        @coordinated = shipments_with_inventory_units - [m]
+        m
+      end
+
+      def proposed_shipments
+        @proposed ||= ProposalCoordinator.new(order).proposed_shipments
+      end
+
+      def shipments_with_inventory_units
+        @coordinated ||= Coordinator.new(order).shipments
+      end
+    end
+  end
+end

--- a/core/app/models/spree/stock/splitter/shipping_category.rb
+++ b/core/app/models/spree/stock/splitter/shipping_category.rb
@@ -29,7 +29,7 @@ module Spree
 
         def shipping_category_for(item)
           @item_shipping_category ||= {}
-          @item_shipping_category[item.inventory_unit.variant_id] ||= item.variant.shipping_category_id
+          @item_shipping_category[item.variant_id] ||= item.shipping_category_id
         end
       end
     end

--- a/core/db/migrate/20161110112737_add_processing_shipments_to_order.rb
+++ b/core/db/migrate/20161110112737_add_processing_shipments_to_order.rb
@@ -1,0 +1,5 @@
+class AddProcessingShipmentsToOrder < ActiveRecord::Migration[5.0]
+  def change
+    add_column :spree_orders, :processing_shipments, :bool, default: false
+  end
+end

--- a/core/db/migrate/20161110112737_add_processing_shipments_to_order.rb
+++ b/core/db/migrate/20161110112737_add_processing_shipments_to_order.rb
@@ -1,5 +1,5 @@
 class AddProcessingShipmentsToOrder < ActiveRecord::Migration[5.0]
   def change
-    add_column :spree_orders, :processing_shipments, :bool, default: false
+    add_column :spree_orders, :processing_shipments, :boolean, default: false
   end
 end

--- a/core/test/jobs/spree/finalize_order_job_test.rb
+++ b/core/test/jobs/spree/finalize_order_job_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+module Spree
+  class FinalizeOrderJobTest < ActiveJob::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end

--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -145,12 +145,14 @@ module Spree
     def before_delivery
       return if params[:order].present?
 
+      @order.allot_content_items_to_shipment_proposal
       packages = @order.shipments.map(&:to_package)
       @differentiator = Spree::Stock::Differentiator.new(@order, packages)
     end
 
     def before_payment
       if @order.checkout_steps.include? "delivery"
+        @order.allot_content_items_to_shipment_proposal
         packages = @order.shipments.map(&:to_package)
         @differentiator = Spree::Stock::Differentiator.new(@order, packages)
         @differentiator.missing.each do |variant, quantity|


### PR DESCRIPTION
1. Use a mock inventory unit object(ProposalInventoryUnit, along with ProposalInventoryUnits) for building shipping proposal and the actual inventory units are built after the order is completed in a delayed job. They are handled by their own packer and coordinator which are subclassed from the original ones. The final inventory units are built using the original coordinator itself. We cannot do this directly from the shipment from ```to_package``` since it would lead to all on_hand/backordered shipment being lumped into one unit.
2. Make the quantity editable for content item. Do not leak content item from inventory units.
3. To prevent inadvertent edits to the order while processing is happening, the queried orders are now scoped under ```editable```. An order is editable if it is currently not being processed or is pending processing.