### PR TITLE
Make priortizer work

### DIFF
--- a/core/app/models/spree/calculator/returns/default_refund_amount.rb
+++ b/core/app/models/spree/calculator/returns/default_refund_amount.rb
@@ -21,8 +21,8 @@ module Spree
       end
 
       def percentage_of_order_total(return_item, inventory_unit)
-       return 0.0 if inventory_unit.order.pre_tax_item_amount.zero?
-       weighted_line_item_pre_tax_amount(return_item, inventory_unit) / inventory_unit.order.pre_tax_item_amount
+        return 0.0 if inventory_unit.order.pre_tax_item_amount.zero?
+        weighted_line_item_pre_tax_amount(return_item, inventory_unit) / inventory_unit.order.pre_tax_item_amount
       end
 
       def weighted_line_item_pre_tax_amount(return_item, inventory_unit)
@@ -32,6 +32,6 @@ module Spree
       def percentage_of_line_item(return_item, inventory_unit)
         return_item.return_quantity / BigDecimal.new(inventory_unit.line_item.quantity)
       end
-   end
- end
+    end
+  end
 end

--- a/core/app/models/spree/inventory_unit.rb
+++ b/core/app/models/spree/inventory_unit.rb
@@ -85,7 +85,7 @@ module Spree
     end
 
     def singular?
-      quantity == 1
+      quantity === 1
     end
 
     # Remove variant default_scope `deleted_at: nil`
@@ -106,7 +106,7 @@ module Spree
     end
 
     def empty?
-      quantity == 0
+      quantity === 0
     end
 
     private

--- a/core/app/models/spree/stock/content_item.rb
+++ b/core/app/models/spree/stock/content_item.rb
@@ -26,6 +26,10 @@ module Spree
         variant_weight * quantity
       end
 
+      def quantity=(value)
+        @inventory_unit.quantity = value
+      end
+
       def on_hand?
         state.to_s == "on_hand"
       end

--- a/core/app/models/spree/stock/coordinator.rb
+++ b/core/app/models/spree/stock/coordinator.rb
@@ -7,7 +7,6 @@ module Spree
       def initialize(order, inventory_units = nil)
         @order = order
         @inventory_units = inventory_units || InventoryUnitBuilder.new(order).units
-        self.unallocated_inventory_units = @inventory_units.dup
       end
 
       def shipments
@@ -18,15 +17,14 @@ module Spree
 
       def packages
         packages = build_packages
-        # packages = prioritize_packages(packages)
+        packages = prioritize_packages(packages)
         packages = estimate_packages(packages)
       end
 
       def build_packages(packages = Array.new)
         stock_locations_with_requested_variants.each do |stock_location|
-          packer = build_packer(stock_location, unallocated_inventory_units)
+          packer = build_packer(stock_location, inventory_units)
           packages += packer.packages
-          self.unallocated_inventory_units -= packer.allocated_inventory_units
         end
 
         packages

--- a/core/app/models/spree/stock/package.rb
+++ b/core/app/models/spree/stock/package.rb
@@ -24,6 +24,10 @@ module Spree
         @contents -= [item] if item
       end
 
+      def remove_item item
+        @contents -= [item]
+      end
+
       # Fix regression that removed package.order.
       # Find it dynamically through an inventory_unit.
       def order

--- a/core/app/models/spree/stock/packer.rb
+++ b/core/app/models/spree/stock/packer.rb
@@ -24,16 +24,14 @@ module Spree
         # Group by variant_id as grouping by variant fires cached query.
         inventory_units.index_by(&:variant_id).each do |variant_id, inventory_unit|
           variant = Spree::Variant.find(variant_id)
-          unit    = inventory_unit
+          unit    = inventory_unit.dup # Can be used by others do not use directly
           if variant.should_track_inventory?
             next unless stock_location.stocks? variant
             on_hand, backordered = stock_location.fill_status(variant, unit.quantity)
             package.add(InventoryUnit.split(unit, backordered), :backordered) if backordered > 0
             package.add(InventoryUnit.split(unit, on_hand),     :on_hand)     if on_hand > 0
-            @allocated_inventory_units << unit if unit.empty?
           else
             package.add unit
-            @allocated_inventory_units << unit
           end
         end
 

--- a/core/app/models/spree/stock/prioritizer.rb
+++ b/core/app/models/spree/stock/prioritizer.rb
@@ -22,27 +22,20 @@ module Spree
         packages.each do |package|
           package.contents.each do |item|
             adjuster = find_adjuster(item)
-
             if adjuster.nil?
               adjuster = build_adjuster(item, package)
-            elsif item.state == :on_hand && adjuster.status == :backordered
-              # Remove item from backordered package
-              adjuster.package.remove(item.inventory_unit)
-              # Reassign adjuster's status package
-              adjuster.reassign(:on_hand, package)
             end
-
-            adjuster.adjust(package)
+            adjuster.adjust(package, item)
           end
         end
       end
 
       def build_adjuster(item, package)
-        @adjusters[item.inventory_unit] = @adjuster_class.new(item.inventory_unit, item.state, package)
+        @adjusters[hash_item item] = @adjuster_class.new(item.inventory_unit, item.state, package)
       end
 
       def find_adjuster(item)
-        @adjusters[item.inventory_unit]
+        @adjusters[hash_item item]
       end
 
       def sort_packages
@@ -51,6 +44,16 @@ module Spree
 
       def prune_packages
         packages.reject! { |pkg| pkg.empty? }
+      end
+
+      def hash_item(item)
+        shipment = item.inventory_unit.shipment
+        variant  = item.inventory_unit.variant
+        if shipment.present?
+          variant.hash ^ shipment.hash
+        else
+          variant.hash
+        end
       end
     end
   end

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -281,14 +281,14 @@ module Spree
                 cost: '14.99',
                 shipping_method: shipping_method.name,
                 stock_location: stock_location.name,
-                inventory_units: 3.times.map { { sku: sku } }
+                inventory_units: 3.times.map { { sku: sku, variant_id: variant.id } }
               },
               {
                 tracking: '123456789',
                 cost: '14.99',
                 shipping_method: shipping_method.name,
                 stock_location: stock_location.name,
-                inventory_units: 2.times.map { { sku: sku } }
+                inventory_units: 2.times.map { { sku: sku, variant_id: variant.id } }
               }
             ]
           }
@@ -315,9 +315,11 @@ module Spree
         it "allocates inventory units to the correct shipments" do
           order = Importer::Order.import(user, params)
 
-          expect(order.inventory_units.count).to eq 5
-          expect(order.shipments.first.inventory_units.count).to eq 3
-          expect(order.shipments.last.inventory_units.count).to eq 2
+          expect(order.inventory_units.count).to eq 2
+          expect(order.shipments.first.inventory_units.count).to eq 1
+          expect(order.shipments.first.inventory_units.first.quantity).to eq 3
+          expect(order.shipments.last.inventory_units.count).to eq 1
+          expect(order.shipments.last.inventory_units.first.quantity).to eq 2
         end
 
         it "accepts admin name for stock location" do


### PR DESCRIPTION
Changes the priortizer and adjuster to maximise the number of on hand items shippable

## Example Scenario

Stock Availability:

Stock Location 1: 50,  Not Backorderable
Stock Location 2: 150, Backorderable
Stock Location 3: 200, Backorderable

Location Priority 1 > 2 > 3

Stock Requested : 10
Current : 10 from Stock Location 1
New     : 10 from Stock Location 1

Stock Requested : 100
Current : 50 from Stock Location 1, 50 from Stock Location 2
New     : 50 from Stock Location 1, 50 from Stock Location 2

Stock Requested : 300
Current : 50 from Stock Location 1, 150 from Stock Location 2, 100 Backordered from Stock Location 2
New     : 50 from Stock Location 1, 150 from Stock Location 2, 100 from Stock Location 3

Stock Requested : 450
Current : 50 from Stock Location 1, 150 from Stock Location 2, 250 Backordered from Stock Location 2
New     : 50 from Stock Location 1, 150 from Stock Location 2, 200 from Stock Location 3, 50 Backordered from Stock Location 2